### PR TITLE
fix: make emoji optional in pr title validation

### DIFF
--- a/scripts/validate-pr-content.js
+++ b/scripts/validate-pr-content.js
@@ -8,18 +8,19 @@ console.log(`🛡️ Validating PR: "${prTitle}"`);
 
 /**
  * 1. PR Title Validation
- * Must start with an emoji, followed by a space and a shorthand type.
- * e.g., "✨ feat: implement something"
+ * Format: "[emoji (optional)] type: description"
+ * e.g., "✨ feat: implement something" or "feat: implement something"
  */
 console.log("   - Checking title format...");
 
-// Simple emoji check: looks for non-ascii characters at the start
-const hasEmojiAtStart = /^[^\x00-\x7F]/.test(prTitle);
-const typeMatch = prTitle.match(/^(?:[^\x00-\x7F]+\s+)(feat|fix|docs|style|refactor|perf|test|build|ci|chore): [a-z0-9].+$/);
+// Emoji is optional: match with or without emoji prefix
+// Pattern: (optional emoji + space) + type + ": " + description (lowercase start)
+const typeMatch = prTitle.match(/^(?:[^\x00-\x7F]+\s+)?(feat|fix|docs|style|refactor|perf|test|build|ci|chore): [a-z0-9].+$/);
 
-if (!hasEmojiAtStart || !typeMatch) {
+if (!typeMatch) {
 	errors.push(`PR Title "${prTitle}" is invalid.
-    Correct format: "✨ [type]: [description]" (Emoji is mandatory!)
+    Correct format: "[emoji] type: description" (emoji is optional)
+    Example: "feat: add new feature" or "✨ feat: add new feature"
     Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore`);
 }
 


### PR DESCRIPTION
## 💡 概要
PRタイトルの絵文字を必須から任意に変更。Git Bashなど一部環境でエンコーディング問題が発生するため。

## 📝 変更内容
- `scripts/validate-pr-content.js` の正規表現を修正
- 絵文字があってもなくてもvalidation通過するように変更

### Before
```
✨ feat: add feature  ← 必須
feat: add feature     ← NG
```

### After
```
✨ feat: add feature  ← OK
feat: add feature     ← OK
```

## 🔗 関連Issue
- Related to #31

## 📷 スクリーンショット（該当する場合）
N/A

## ✅ チェックリスト
- [x] スクリプト修正完了
- [x] 絵文字あり/なし両方でvalidation通過を確認

## 📌 補足事項
本PRは絵文字なしタイトルでテストを兼ねています。

## 📝 PRタイトルの命名規則:
fix: make emoji optional in PR title validation

## 📖 レビュー用語集
N/A
