### PR TITLE
fix: support scope in pr title validation

### DIFF
--- a/scripts/validate-pr-content.js
+++ b/scripts/validate-pr-content.js
@@ -8,19 +8,19 @@ console.log(`🛡️ Validating PR: "${prTitle}"`);
 
 /**
  * 1. PR Title Validation
- * Format: "[emoji (optional)] type: description"
- * e.g., "✨ feat: implement something" or "feat: implement something"
+ * Format: "[emoji (optional)] type[(scope)]: description"
+ * e.g., "✨ feat: implement something" or "feat(ui): add component"
  */
 console.log("   - Checking title format...");
 
 // Emoji is optional: match with or without emoji prefix
-// Pattern: (optional emoji + space) + type + ": " + description (lowercase start)
-const typeMatch = prTitle.match(/^(?:[^\x00-\x7F]+\s+)?(feat|fix|docs|style|refactor|perf|test|build|ci|chore): [a-z0-9].+$/);
+// Pattern: (optional emoji + space) + type + (optional scope) + ": " + description (lowercase start)
+const typeMatch = prTitle.match(/^(?:[^\x00-\x7F]+\s+)?(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(?:\([a-z0-9-]+\))?: [a-z0-9].+$/);
 
 if (!typeMatch) {
 	errors.push(`PR Title "${prTitle}" is invalid.
-    Correct format: "[emoji] type: description" (emoji is optional)
-    Example: "feat: add new feature" or "✨ feat: add new feature"
+    Correct format: "[emoji] type[(scope)]: description" (emoji is optional)
+    Example: "feat: add feature" or "feat(ui): add component"
     Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore`);
 }
 


### PR DESCRIPTION
## 💡 概要
PRタイトルのvalidationでConventional Commitsのスコープをサポートする。

## 📝 変更内容
- 正規表現に `(?:\([a-z0-9-]+\))?` を追加
- `feat(ui): add button` 形式が通るように

### Before
```
feat: description     ← OK
feat(ui): description ← NG
```

### After
```
feat: description     ← OK
feat(ui): description ← OK
```

## 🔗 関連Issue
- Related to #31

## 📷 スクリーンショット（該当する場合）
N/A

## ✅ チェックリスト
- [x] 正規表現修正

## 📌 補足事項
PR #36 (pt-card compound) のために必要な修正

## 📝 PRタイトルの命名規則:
fix: support scope in pr title validation

## 📖 レビュー用語集
- Conventional Commits: コミットメッセージの標準形式
