### PR TITLE
feat(ui): use pt-card compound components in quiz

### DIFF
--- a/knip.config.js
+++ b/knip.config.js
@@ -7,9 +7,6 @@ module.exports = {
 		'scripts/download-icons.js',
 		// TODO: Remove when first component imports tokens (see Issue #34)
 		'src/design-system/tokens/**/*',
-		// TODO: Remove when quiz.ts uses compound components
-		'src/app/ui/pt-card/pt-card-*.ts',
-		'src/app/ui/pt-card/index.ts',
 		'src/styles/generated/**/*',
 	],
 	ignoreDependencies: [

--- a/src/app/features/quiz/quiz.ts
+++ b/src/app/features/quiz/quiz.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PokemonService } from '../../domain/pokemon.service';
 import { Pokemon } from '../../domain/pokemon.schema';
-import { CardComponent } from '../../ui/pt-card/pt-card';
+import { CardComponent, CardHeaderComponent, CardContentComponent, CardFooterComponent } from '../../ui/pt-card';
 import { TypeBadgeComponent } from './components/type-badge';
 import { ButtonComponent } from '../../ui/pt-button/pt-button';
 import { POKEMON_TYPES, POKEMON_TYPES_MAP, getEffectiveness, PokemonType } from '../../domain/type-chart';
@@ -10,15 +10,17 @@ import { POKEMON_TYPES, POKEMON_TYPES_MAP, getEffectiveness, PokemonType } from 
 @Component({
   selector: 'app-quiz',
   standalone: true,
-  imports: [CommonModule, CardComponent, TypeBadgeComponent, ButtonComponent],
+  imports: [CommonModule, CardComponent, CardHeaderComponent, CardContentComponent, CardFooterComponent, TypeBadgeComponent, ButtonComponent],
   template: `
     <div class="max-w-xl mx-auto py-8 px-4">
       <pt-card *ngIf="currentPokemon() as pokemon">
-        <div class="text-center">
-          <div class="flex justify-between items-center mb-4">
+        <pt-card-header>
+          <div class="flex justify-between items-center">
             <span class="text-text-secondary text-xs font-bold uppercase tracking-widest italic">Phase 0: Battle Trial</span>
             <span class="text-primary font-black">Lv. 100</span>
           </div>
+        </pt-card-header>
+        <pt-card-content class="text-center">
           
           <div class="flex flex-col sm:flex-row items-center gap-6 mb-8 justify-center bg-slate-50/50 p-6 rounded-3xl border border-slate-100">
             <!-- Attacker -->
@@ -102,18 +104,16 @@ import { POKEMON_TYPES, POKEMON_TYPES_MAP, getEffectiveness, PokemonType } from 
             </p>
           </div>
 
-          <!-- Actions -->
-          <div class="h-14">
-            <pt-button 
-              *ngIf="isChecked()" 
-              variant="primary" 
-              (buttonClick)="next()"
-              class="w-full"
-            >
-              つぎの問題へ
-            </pt-button>
-          </div>
-        </div>
+        </pt-card-content>
+        <pt-card-footer *ngIf="isChecked()">
+          <pt-button 
+            variant="primary" 
+            (buttonClick)="next()"
+            class="w-full"
+          >
+            つぎの問題へ
+          </pt-button>
+        </pt-card-footer>
       </pt-card>
 
       <!-- Skeleton / Loading -->


### PR DESCRIPTION
## 💡 概要
quiz.tsでpt-cardのCompound Components（header/content/footer）を使用し、knip除外を削除。

## 📝 変更内容
- `quiz.ts`にCompound Componentsをインポート・使用
- `knip.config.js`からpt-card除外を削除

## 🔗 関連Issue
- Closes #38
- Closes #14

## 📷 スクリーンショット（該当する場合）
N/A

## ✅ チェックリスト
- [x] ビルド成功
- [x] knip除外削除

## 📌 補足事項
Issue #14 (Compound Components作成) はPR #36で完了していたがクローズ漏れ。

## 📝 PRタイトルの命名規則:
feat(ui): use pt-card compound components in quiz

## 📖 レビュー用語集
N/A
