### PR TITLE
refactor: Phase 2-3 Layout Primitives and Quiz screen rewrite

### DIFF
--- a/design-tokens/tier2-semantic/effects.json
+++ b/design-tokens/tier2-semantic/effects.json
@@ -51,6 +51,11 @@
 				"type": "borderRadius",
 				"$description": "【用途】大きな要素。カード、パネル。"
 			},
+			"xl": {
+				"value": "{radius.xl}",
+				"type": "borderRadius",
+				"$description": "【用途】特大コンテナ。モーダル、大きなサーフェス。"
+			},
 			"pill": {
 				"value": "{radius.full}",
 				"type": "borderRadius",

--- a/design-tokens/tier2-semantic/spacing.json
+++ b/design-tokens/tier2-semantic/spacing.json
@@ -63,6 +63,11 @@
 				"value": "{space.6}",
 				"type": "spacing",
 				"$description": "隣接要素間の距離を表す。セクション内のカード間など広い間隔。"
+			},
+			"xl": {
+				"value": "{space.8}",
+				"type": "spacing",
+				"$description": "隣接要素間の距離を表す。セクション間の明確な分割など特大の間隔。"
 			}
 		}
 	}

--- a/design-tokens/tier3-component/grid.json
+++ b/design-tokens/tier3-component/grid.json
@@ -1,0 +1,57 @@
+{
+	"$description": "Tier 3: Grid Component Tokens. CSS Grid layout primitive for consistent column-based layouts.",
+	"grid": {
+		"$description": "Grid component for arranging elements in responsive column layouts.",
+		"columns": {
+			"$description": "Available column counts. Represents layout density options.",
+			"1": {
+				"value": 1,
+				"type": "number",
+				"$description": "1カラム。モバイルでの単一カラム表示。"
+			},
+			"2": {
+				"value": 2,
+				"type": "number",
+				"$description": "2カラム。選択肢表示のデフォルト。"
+			},
+			"3": {
+				"value": 3,
+				"type": "number",
+				"$description": "3カラム。sm以上での選択肢表示。"
+			},
+			"4": {
+				"value": 4,
+				"type": "number",
+				"$description": "4カラム。ギャラリー表示など。"
+			},
+			"6": {
+				"value": 6,
+				"type": "number",
+				"$description": "6カラム。高密度レイアウト。"
+			}
+		},
+		"gap": {
+			"$description": "Grid items間のギャップサイズ。spacing.gap tokens を参照。",
+			"none": {
+				"value": "0",
+				"type": "spacing",
+				"$description": "ギャップなし。"
+			},
+			"sm": {
+				"value": "{spacing.gap.sm}",
+				"type": "spacing",
+				"$description": "小ギャップ。コンパクトなグリッド。"
+			},
+			"md": {
+				"value": "{spacing.gap.md}",
+				"type": "spacing",
+				"$description": "中ギャップ。標準グリッド。デフォルト値。"
+			},
+			"lg": {
+				"value": "{spacing.gap.lg}",
+				"type": "spacing",
+				"$description": "大ギャップ。ゆったりしたグリッド。"
+			}
+		}
+	}
+}

--- a/design-tokens/tier3-component/stack.json
+++ b/design-tokens/tier3-component/stack.json
@@ -1,0 +1,39 @@
+{
+	"$description": "Tier 3: Stack Component Tokens. Flexbox-based layout primitive for consistent spacing and alignment.",
+	"stack": {
+		"$description": "Stack component for arranging elements vertically or horizontally with consistent spacing.",
+		"gap": {
+			"$description": "Gap sizes between stack items. References semantic spacing.gap tokens.",
+			"none": {
+				"value": "0",
+				"type": "spacing",
+				"$description": "ギャップなし。要素同士を密着させる場合に使用。"
+			},
+			"xs": {
+				"value": "{spacing.gap.xs}",
+				"type": "spacing",
+				"$description": "極小ギャップ。アイコンとラベルなど密接な要素間。"
+			},
+			"sm": {
+				"value": "{spacing.gap.sm}",
+				"type": "spacing",
+				"$description": "小ギャップ。関連性の高い要素間。"
+			},
+			"md": {
+				"value": "{spacing.gap.md}",
+				"type": "spacing",
+				"$description": "中ギャップ。標準的な要素間。デフォルト値。"
+			},
+			"lg": {
+				"value": "{spacing.gap.lg}",
+				"type": "spacing",
+				"$description": "大ギャップ。セクション内の区切り。"
+			},
+			"xl": {
+				"value": "{spacing.gap.xl}",
+				"type": "spacing",
+				"$description": "特大ギャップ。セクション間の明確な分割。"
+			}
+		}
+	}
+}

--- a/design-tokens/tier3-component/surface.json
+++ b/design-tokens/tier3-component/surface.json
@@ -1,0 +1,110 @@
+{
+	"$description": "Tier 3: Surface Component Tokens. Container styling primitive for backgrounds, borders, and radii.",
+	"surface": {
+		"$description": "Surface component for consistent container styling. Provides visual containment for content.",
+		"variant": {
+			"$description": "Background variants. default/subtle/card/ghost correspond to different visual hierarchy levels.",
+			"default": {
+				"background": {
+					"value": "{color.surface.card}",
+					"type": "color",
+					"$description": "デフォルト背景。白色ベース。"
+				}
+			},
+			"subtle": {
+				"background": {
+					"value": "{color.surface.page}",
+					"type": "color",
+					"$description": "控えめな背景。セクション区分けに使用。"
+				}
+			},
+			"card": {
+				"background": {
+					"value": "{color.surface.card}",
+					"type": "color",
+					"$description": "カード背景。elevationと併用。"
+				},
+				"elevation": {
+					"value": "{elevation.raised}",
+					"type": "boxShadow",
+					"$description": "カードの影。軽く浮いた状態。"
+				}
+			},
+			"ghost": {
+				"background": {
+					"value": "transparent",
+					"type": "color",
+					"$description": "透明背景。親要素の背景を透過。"
+				}
+			}
+		},
+		"padding": {
+			"$description": "内側の余白サイズ。spacing.content tokens を参照。",
+			"none": {
+				"value": "0",
+				"type": "spacing",
+				"$description": "パディングなし。"
+			},
+			"sm": {
+				"value": "{spacing.content.sm}",
+				"type": "spacing",
+				"$description": "小パディング。コンパクトなコンテナ。"
+			},
+			"md": {
+				"value": "{spacing.content.md}",
+				"type": "spacing",
+				"$description": "中パディング。標準的なコンテナ。デフォルト値。"
+			},
+			"lg": {
+				"value": "{spacing.content.lg}",
+				"type": "spacing",
+				"$description": "大パディング。ゆったりしたコンテナ。"
+			}
+		},
+		"radius": {
+			"$description": "角丸サイズ。semantic-border.radius tokens を参照。",
+			"none": {
+				"value": "{semantic-border.radius.none}",
+				"type": "borderRadius",
+				"$description": "角丸なし。"
+			},
+			"sm": {
+				"value": "{semantic-border.radius.sm}",
+				"type": "borderRadius",
+				"$description": "小角丸。"
+			},
+			"md": {
+				"value": "{semantic-border.radius.md}",
+				"type": "borderRadius",
+				"$description": "中角丸。デフォルト値。"
+			},
+			"lg": {
+				"value": "{semantic-border.radius.lg}",
+				"type": "borderRadius",
+				"$description": "大角丸。"
+			},
+			"xl": {
+				"value": "{semantic-border.radius.xl}",
+				"type": "borderRadius",
+				"$description": "特大角丸。大きなコンテナやモーダル。"
+			},
+			"full": {
+				"value": "{semantic-border.radius.pill}",
+				"type": "borderRadius",
+				"$description": "完全円形/ピル形状。"
+			}
+		},
+		"border": {
+			"color": {
+				"value": "{color.border.default}",
+				"type": "color",
+				"$description": "ボーダー色。"
+			},
+			"width": {
+				"value": "{semantic-border.width.default}",
+				"type": "borderWidth",
+				"$description": "ボーダー幅。"
+			}
+		}
+	}
+}

--- a/docs/components/pt-grid.md
+++ b/docs/components/pt-grid.md
@@ -1,0 +1,136 @@
+# pt-grid
+
+> CSS Gridベースの規則的なカラムレイアウトプリミティブ
+
+**ベンチマーク**: [MUI Grid](https://mui.com/material-ui/react-grid/) | [Chakra UI SimpleGrid](https://chakra-ui.com/docs/components/simple-grid)
+
+---
+
+## Overview
+
+`pt-grid` は要素を規則的なカラムグリッドに配置するレイアウトコンポーネントです。CSS Gridを使用し、レスポンシブなカラム数変更をサポートします。
+
+---
+
+## When to use ✅
+
+| シチュエーション | 説明 |
+|------------------|------|
+| **選択肢ボタン群** | Quiz画面の倍率選択など |
+| **カードリスト** | 同じサイズのカードを並べる |
+| **ギャラリー** | 画像サムネイル表示 |
+| **レスポンシブカラム** | モバイル2列→デスクトップ3列 |
+
+---
+
+## When not to use ❌ (Anti-patterns)
+
+| アンチパターン | 理由 | 代替案 |
+|----------------|------|--------|
+| **1列レイアウト** | Gridの意味がない | `pt-stack` |
+| **異なるサイズの要素** | Gridは均等配分が前提 | `pt-stack` + CSS |
+| **複雑なレイアウト** | 12カラムシステム等 | CSS直接記述 |
+
+---
+
+## Specs
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `1 \| 2 \| 3 \| 4 \| 6` | `2` | カラム数（モバイル/デフォルト） |
+| `smColumns` | `1 \| 2 \| 3 \| 4 \| 6 \| undefined` | `undefined` | sm (640px+) でのカラム数 |
+| `gap` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` | グリッド間ギャップ |
+
+### Column Options
+
+| Columns | 用途 |
+|---------|------|
+| `1` | モバイル単一カラム |
+| `2` | 選択肢ペア、2択ボタン |
+| `3` | Quiz選択肢（デスクトップ） |
+| `4` | ギャラリー、アイコン群 |
+| `6` | 高密度レイアウト |
+
+### Design Tokens
+
+| Token | Reference | Value | 用途 |
+|-------|-----------|-------|------|
+| `grid.columns.*` | - | `1-6` | カラム数オプション |
+| `grid.gap.none` | - | `0` | ギャップなし |
+| `grid.gap.sm` | `{spacing.gap.sm}` | 8px | コンパクト |
+| `grid.gap.md` | `{spacing.gap.md}` | 16px | 標準（default） |
+| `grid.gap.lg` | `{spacing.gap.lg}` | 24px | ゆったり |
+
+---
+
+## Accessibility
+
+- グリッド自体にはARIA属性不要
+- 内包要素の順序がDOMの順序と一致することを確認
+- キーボードナビゲーションは内包要素で対応
+
+---
+
+## Examples
+
+### Basic Grid (2 columns)
+
+```html
+<pt-grid [columns]="2" gap="md">
+  <button>選択肢1</button>
+  <button>選択肢2</button>
+  <button>選択肢3</button>
+  <button>選択肢4</button>
+</pt-grid>
+```
+
+### Responsive Grid
+
+```html
+<pt-grid [columns]="2" [smColumns]="3" gap="md">
+  <button *ngFor="let choice of choices">{{ choice }}</button>
+</pt-grid>
+```
+
+### Card Gallery
+
+```html
+<pt-grid [columns]="2" [smColumns]="4" gap="lg">
+  <pt-surface *ngFor="let item of items" variant="card" padding="md">
+    <img [src]="item.image" [alt]="item.name">
+    <p>{{ item.name }}</p>
+  </pt-surface>
+</pt-grid>
+```
+
+---
+
+## Design Patterns
+
+### Quiz Choices (Current Usage)
+
+```html
+<pt-grid [columns]="2" [smColumns]="3" gap="md">
+  <button *ngFor="let choice of [4, 2, 1, 0.5, 0.25, 0]"
+          (click)="selectChoice(choice)">
+    {{ choice }}倍
+  </button>
+</pt-grid>
+```
+
+---
+
+## Related Components
+
+- `pt-stack`: 縦/横の積み上げレイアウト
+- `pt-surface`: グリッド内カードのスタイリング
+
+---
+
+## References
+
+- [MUI Grid](https://mui.com/material-ui/react-grid/)
+- [Chakra UI SimpleGrid](https://chakra-ui.com/docs/components/simple-grid)
+- [CSS Grid Layout (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout)

--- a/docs/components/pt-stack.md
+++ b/docs/components/pt-stack.md
@@ -1,0 +1,133 @@
+# pt-stack
+
+> Flexboxベースの積み上げレイアウトプリミティブ
+
+**ベンチマーク**: [Chakra UI Stack](https://chakra-ui.com/docs/components/stack) | [MUI Stack](https://mui.com/material-ui/react-stack/)
+
+---
+
+## Overview
+
+`pt-stack` は要素を縦または横に積み上げ、一貫したギャップを適用するレイアウトコンポーネントです。Flexboxを使用し、配置・整列を宣言的に制御できます。
+
+---
+
+## When to use ✅
+
+| シチュエーション | 説明 |
+|------------------|------|
+| **縦に並べたい要素群** | フォームフィールド、カード内のテキスト群 |
+| **横に並べたい要素群** | ボタン群、アイコン+テキスト |
+| **レスポンシブレイアウト** | モバイルは縦、デスクトップは横 |
+| **一貫したギャップが必要** | Design Tokensに基づくスペーシング |
+
+---
+
+## When not to use ❌ (Anti-patterns)
+
+| アンチパターン | 理由 | 代替案 |
+|----------------|------|--------|
+| **グリッドレイアウト** | n列の規則正しい配置はGridの責務 | `pt-grid` |
+| **単一要素** | Stackの意味がない | 直接スタイル |
+| **複雑なネスト** | 可読性が下がる | 適切なセクション分割 |
+
+---
+
+## Specs
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `direction` | `'vertical' \| 'horizontal' \| 'responsive'` | `'vertical'` | 積み上げ方向 |
+| `gap` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | 要素間ギャップ |
+| `align` | `'start' \| 'center' \| 'end' \| 'stretch'` | `'stretch'` | 交差軸の配置 |
+| `justify` | `'start' \| 'center' \| 'end' \| 'between'` | `'start'` | 主軸の配置 |
+
+### Design Tokens
+
+| Token | Reference | Value | 用途 |
+|-------|-----------|-------|------|
+| `stack.gap.none` | - | `0` | 密着配置 |
+| `stack.gap.xs` | `{spacing.gap.xs}` | 4px | 密接な要素間 |
+| `stack.gap.sm` | `{spacing.gap.sm}` | 8px | 関連要素間 |
+| `stack.gap.md` | `{spacing.gap.md}` | 16px | 標準（default） |
+| `stack.gap.lg` | `{spacing.gap.lg}` | 24px | セクション内区切り |
+| `stack.gap.xl` | `{spacing.content.xl}` | 32px | 明確な分割 |
+
+---
+
+## Accessibility
+
+- スタック自体にはARIA属性不要
+- 内包要素の順序がDOMの順序と一致することを確認
+
+---
+
+## Examples
+
+### Basic Vertical Stack
+
+```html
+<pt-stack direction="vertical" gap="md">
+  <h2>タイトル</h2>
+  <p>説明文</p>
+</pt-stack>
+```
+
+### Horizontal Stack (Button Group)
+
+```html
+<pt-stack direction="horizontal" gap="sm" align="center">
+  <pt-button>キャンセル</pt-button>
+  <pt-button variant="primary">保存</pt-button>
+</pt-stack>
+```
+
+### Responsive Stack
+
+```html
+<pt-stack direction="responsive" gap="lg" align="center">
+  <pt-avatar src="..." alt="ピカチュウ"></pt-avatar>
+  <div>
+    <h2>ピカチュウ</h2>
+    <pt-type-chip type="electric">でんき</pt-type-chip>
+  </div>
+</pt-stack>
+```
+
+---
+
+## Design Patterns
+
+### Centered Content
+
+```html
+<pt-stack direction="vertical" gap="md" align="center" justify="center">
+  <!-- 中央揃えコンテンツ -->
+</pt-stack>
+```
+
+### Space Between
+
+```html
+<pt-stack direction="horizontal" justify="between" align="center">
+  <span>左寄せ</span>
+  <span>右寄せ</span>
+</pt-stack>
+```
+
+---
+
+## Related Components
+
+- `pt-grid`: 規則的なグリッドレイアウト
+- `pt-surface`: 背景・枠線などのコンテナスタイリング
+
+---
+
+## References
+
+- [Chakra UI Stack](https://chakra-ui.com/docs/components/stack)
+- [MUI Stack](https://mui.com/material-ui/react-stack/)
+- [Every Layout: Stack](https://every-layout.dev/layouts/stack/)

--- a/docs/components/pt-surface.md
+++ b/docs/components/pt-surface.md
@@ -1,0 +1,145 @@
+# pt-surface
+
+> コンテナの見た目（背景、枠線、角丸、パディング）を提供するスタイリングプリミティブ
+
+**ベンチマーク**: [MUI Paper](https://mui.com/material-ui/react-paper/) | [Radix UI Box](https://www.radix-ui.com/primitives)
+
+---
+
+## Overview
+
+`pt-surface` は背景色、枠線、角丸、パディングを一括で制御するコンテナコンポーネントです。レイアウト構造（Stack/Grid）とは独立した視覚的な「面」を表現します。
+
+---
+
+## When to use ✅
+
+| シチュエーション | 説明 |
+|------------------|------|
+| **背景色で区切りたい** | セクションの視覚的分離 |
+| **カード風の見た目** | 影付きの浮いたコンテナ |
+| **一貫したパディング** | Design Tokensに基づく余白 |
+| **構造とスタイルの分離** | pt-stackと組み合わせて使用 |
+
+---
+
+## When not to use ❌ (Anti-patterns)
+
+| アンチパターン | 理由 | 代替案 |
+|----------------|------|--------|
+| **単なるdivラッパー** | ghost+padding-noneなら意味がない | 直接スタイル |
+| **pt-card の置き換え** | カードはヘッダー/フッター構造を持つ | `pt-card` |
+| **レイアウト制御** | 配置はSurfaceの責務外 | `pt-stack`, `pt-grid` |
+
+---
+
+## Specs
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'default' \| 'subtle' \| 'card' \| 'ghost'` | `'default'` | 背景スタイル |
+| `padding` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` | 内側余白 |
+| `radius` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` | 角丸 |
+| `border` | `boolean` | `false` | 枠線の有無 |
+
+### Variant Details
+
+| Variant | Background | Shadow | 用途 |
+|---------|------------|--------|------|
+| `default` | 白 | なし | 標準背景 |
+| `subtle` | 薄いグレー | なし | セクション区分け |
+| `card` | 白 | あり | 浮いたカード風 |
+| `ghost` | 透明 | なし | 親の背景を透過 |
+
+### Design Tokens
+
+| Token | Reference | 用途 |
+|-------|-----------|------|
+| `surface.variant.default.background` | `{color.surface}` | 白背景 |
+| `surface.variant.subtle.background` | `{color.surface-subtle}` | 薄いグレー背景 |
+| `surface.variant.card.elevation` | `{elevation.raised}` | カードの影 |
+| `surface.padding.*` | `{spacing.content.*}` | パディング |
+| `surface.radius.*` | `{semantic-border.radius.*}` | 角丸 |
+| `surface.border.width` | `{semantic-border.width.default}` | 枠線幅 |
+
+---
+
+## Accessibility
+
+- Surfaceは視覚的なコンテナであり、ARIA属性不要
+- 背景色とテキスト色のコントラスト比に注意
+
+---
+
+## Examples
+
+### Basic Surface
+
+```html
+<pt-surface variant="subtle" padding="lg" radius="xl">
+  <p>控えめな背景のコンテナ</p>
+</pt-surface>
+```
+
+### Card-like Surface
+
+```html
+<pt-surface variant="card" padding="md" radius="lg" [border]="true">
+  <h3>カード風</h3>
+  <p>影と枠線付き</p>
+</pt-surface>
+```
+
+### Combined with Stack
+
+```html
+<pt-surface variant="subtle" padding="lg" radius="xl">
+  <pt-stack direction="horizontal" gap="lg" align="center">
+    <pt-avatar src="..." alt="..."></pt-avatar>
+    <div>
+      <h2>ポケモン名</h2>
+      <pt-type-chip type="fire">ほのお</pt-type-chip>
+    </div>
+  </pt-stack>
+</pt-surface>
+```
+
+---
+
+## Design Patterns
+
+### Section Background
+
+```html
+<pt-surface variant="subtle" padding="lg" radius="xl" [border]="true">
+  <!-- セクションコンテンツ -->
+</pt-surface>
+```
+
+### Ghost Surface (inheritance)
+
+```html
+<div style="background: linear-gradient(...)">
+  <pt-surface variant="ghost" padding="md">
+    <!-- 親の背景を透過 -->
+  </pt-surface>
+</div>
+```
+
+---
+
+## Related Components
+
+- `pt-stack`: レイアウト構造（併用推奨）
+- `pt-card`: ヘッダー/コンテンツ/フッター構造を持つカード
+- `pt-grid`: グリッドレイアウト
+
+---
+
+## References
+
+- [MUI Paper](https://mui.com/material-ui/react-paper/)
+- [Radix UI Box](https://www.radix-ui.com/primitives)
+- [Every Layout: Box](https://every-layout.dev/layouts/box/)

--- a/src/app/features/quiz/quiz.ts
+++ b/src/app/features/quiz/quiz.ts
@@ -6,6 +6,9 @@ import { CardComponent, CardHeaderComponent, CardContentComponent } from '../../
 import { TypeChipComponent } from '../../ui/pt-type-chip/pt-type-chip';
 import { AvatarComponent } from '../../ui/pt-avatar/pt-avatar';
 import { IconComponent } from '../../ui/pt-icon/pt-icon';
+import { StackComponent } from '../../ui/pt-stack/pt-stack';
+import { SurfaceComponent } from '../../ui/pt-surface/pt-surface';
+import { GridComponent } from '../../ui/pt-grid/pt-grid';
 import { POKEMON_TYPES, POKEMON_TYPES_MAP, getEffectiveness, PokemonType } from '../../domain/type-chart';
 
 /** 回答後に次の問題へ進むまでの遅延（ミリ秒） */
@@ -14,89 +17,217 @@ const AUTO_ADVANCE_DELAY_MS = 1000;
 @Component({
   selector: 'app-quiz',
   standalone: true,
-  imports: [CommonModule, CardComponent, CardHeaderComponent, CardContentComponent, TypeChipComponent, AvatarComponent, IconComponent],
+  imports: [CommonModule, CardComponent, CardHeaderComponent, CardContentComponent, TypeChipComponent, AvatarComponent, IconComponent, StackComponent, SurfaceComponent, GridComponent],
   template: `
-    <div class="max-w-xl mx-auto py-8 px-4">
+    <pt-surface variant="ghost" padding="lg" class="quiz-container">
       <pt-card *ngIf="currentPokemon() as pokemon">
         <pt-card-header>
-          <div class="flex justify-between items-center">
-            <span class="text-text-secondary text-xs font-bold uppercase tracking-widest italic">Phase 0: Battle Trial</span>
-            <span class="text-primary font-black">Lv. 100</span>
-          </div>
+          <pt-stack direction="horizontal" justify="between" align="center">
+            <span class="quiz-phase-label">Phase 0: Battle Trial</span>
+            <span class="quiz-level">Lv. 100</span>
+          </pt-stack>
         </pt-card-header>
-        <pt-card-content class="text-center">
-          
-          <div class="flex flex-col sm:flex-row items-center gap-6 mb-8 justify-center bg-slate-50/50 p-6 rounded-3xl border border-slate-100">
-            <!-- Attacker -->
-            <div class="flex flex-col items-center">
-              <span class="text-[10px] font-black uppercase text-slate-400 mb-2">こうげき側 (タイプ)</span>
-              <div class="bg-white p-6 rounded-3xl shadow-sm border border-slate-100 min-w-32 text-center transform transition-transform hover:scale-105">
-                <pt-type-chip 
-                  [type]="attackType()"
-                  [showIcon]="true"
-                  rounded="full"
-                  size="lg"
-                  class="mx-auto">
-                </pt-type-chip>
-                <span 
-                  class="text-lg font-black"
-                  [style.color]="'var(--color-text-type-' + attackType() + ')'"
-                >
-                  {{ typeMap[attackType()] }}
-                </span>
-              </div>
-            </div>
+        <pt-card-content>
+          <pt-stack direction="vertical" gap="lg" align="stretch">
             
-            <pt-icon src="/icons/arrow-right-double.svg" size="lg" class="text-slate-200"></pt-icon>
+            <!-- 攻撃側・防御側エリア -->
+            <pt-surface variant="subtle" padding="lg" radius="xl" [border]="true">
+              <pt-stack direction="responsive" gap="lg" align="center" justify="center">
+                <!-- Attacker -->
+                <pt-stack direction="vertical" gap="sm" align="center">
+                  <span class="quiz-section-label">こうげき側 (タイプ)</span>
+                  <pt-surface variant="card" padding="lg" radius="xl" [border]="true" class="attacker-card">
+                    <pt-stack direction="vertical" gap="sm" align="center">
+                      <pt-type-chip 
+                        [type]="attackType()"
+                        [showIcon]="true"
+                        rounded="full"
+                        size="lg">
+                      </pt-type-chip>
+                      <span 
+                        class="type-name"
+                        [style.color]="'var(--pt-color-pokemon-text-' + attackType() + ')'"
+                      >
+                        {{ typeMap[attackType()] }}
+                      </span>
+                    </pt-stack>
+                  </pt-surface>
+                </pt-stack>
+                
+                <pt-icon src="/icons/arrow-right-double.svg" size="lg" class="arrow-icon"></pt-icon>
 
-            <!-- Defender -->
-            <div class="flex flex-col items-center">
-               <span class="text-[10px] font-black uppercase text-slate-400 mb-2">ぼうぎょ側 (ポケモン)</span>
-               <div class="flex items-center gap-4 bg-white p-4 pr-8 rounded-3xl shadow-sm border border-slate-100 transform transition-transform hover:scale-105">
-                <!-- TODO: pt-paper導入後に置き換え -->
-                <div class="bg-slate-50 rounded-xl p-1 shadow-inner">
-                  <pt-avatar
-                    [src]="pokemon.imageUrl"
-                    [alt]="pokemon.name"
-                    size="lg"
-                    shape="rounded"
-                    [pixelated]="true">
-                  </pt-avatar>
-                </div>
-                <div class="text-left">
-                  <h2 class="text-xl font-extrabold">{{ pokemon.name }}</h2>
-                  <div class="flex gap-1.5 mt-1">
-                    <pt-type-chip *ngFor="let t of pokemon.types; let i = index" [type]="t" size="sm" rounded="sm">
-                      {{ pokemon.jaTypes[i] }}
-                    </pt-type-chip>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+                <!-- Defender -->
+                <pt-stack direction="vertical" gap="sm" align="center">
+                  <span class="quiz-section-label">ぼうぎょ側 (ポケモン)</span>
+                  <pt-surface variant="card" padding="md" radius="xl" [border]="true">
+                    <pt-stack direction="horizontal" gap="md" align="center">
+                      <pt-surface variant="subtle" padding="sm" radius="lg">
+                        <pt-avatar
+                          [src]="pokemon.imageUrl"
+                          [alt]="pokemon.name"
+                          size="lg"
+                          shape="rounded"
+                          [pixelated]="true">
+                        </pt-avatar>
+                      </pt-surface>
+                      <pt-stack direction="vertical" gap="xs" align="start">
+                        <span class="pokemon-name">{{ pokemon.name }}</span>
+                        <pt-stack direction="horizontal" gap="xs">
+                          <pt-type-chip *ngFor="let t of pokemon.types; let i = index" [type]="t" size="sm" rounded="sm">
+                            {{ pokemon.jaTypes[i] }}
+                          </pt-type-chip>
+                        </pt-stack>
+                      </pt-stack>
+                    </pt-stack>
+                  </pt-surface>
+                </pt-stack>
+              </pt-stack>
+            </pt-surface>
 
-          <div class="mb-8">
-            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 px-2">
+            <!-- 選択肢 -->
+            <pt-grid [columns]="2" [smColumns]="3" gap="md">
               <button
                 *ngFor="let choice of choices"
                 (click)="selectChoice(choice)"
                 [class]="getChoiceButtonClass(choice)"
                 [disabled]="isChecked()"
               >
-                <span class="text-3xl font-black">{{ choice }}</span>
-                <span class="text-xs font-bold ml-1 opacity-70">倍</span>
+                <span class="choice-value">{{ choice }}</span>
+                <span class="choice-unit">倍</span>
               </button>
-            </div>
-          </div>
+            </pt-grid>
 
+          </pt-stack>
         </pt-card-content>
       </pt-card>
 
-      <!-- ローディング状態: 現在は瞬時に完了するため空表示（300ms以上かかる場合のみスピナーを検討） -->
-      <div *ngIf="!currentPokemon()" class="h-80"></div>
-    </div>
+      <!-- ローディング状態 -->
+      <pt-surface *ngIf="!currentPokemon()" variant="ghost" class="loading-placeholder"></pt-surface>
+    </pt-surface>
   `,
-  styles: [],
+  styles: [`
+    .quiz-container {
+      max-width: 36rem;
+      margin-inline: auto;
+    }
+    
+    .quiz-phase-label {
+      font-size: var(--pt-font-size-xs);
+      font-weight: var(--pt-font-weight-bold);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-style: italic;
+      color: var(--pt-color-text-secondary);
+    }
+    
+    .quiz-level {
+      font-weight: var(--pt-font-weight-bold);
+      color: var(--pt-color-text-primary);
+    }
+    
+    .quiz-section-label {
+      font-size: 0.625rem; /* 10px - 極小ラベル */
+      font-weight: var(--pt-font-weight-bold);
+      text-transform: uppercase;
+      color: var(--pt-color-text-secondary);
+    }
+    
+    .attacker-card {
+      min-width: 8rem;
+      text-align: center;
+    }
+    
+    .type-name {
+      font-size: var(--pt-font-size-lg);
+      font-weight: var(--pt-font-weight-bold);
+    }
+    
+    .arrow-icon {
+      color: var(--pt-color-text-disabled);
+    }
+    
+    .pokemon-name {
+      font-size: var(--pt-font-size-xl);
+      font-weight: var(--pt-font-weight-bold);
+      color: var(--pt-color-text-primary);
+    }
+    
+    .choice-value {
+      font-size: var(--pt-font-size-3xl);
+      font-weight: var(--pt-font-weight-bold);
+    }
+    
+    .choice-unit {
+      font-size: var(--pt-font-size-xs);
+      font-weight: var(--pt-font-weight-bold);
+      margin-inline-start: var(--pt-space-1);
+      opacity: 0.7;
+    }
+    
+    .loading-placeholder {
+      height: 20rem;
+    }
+    
+    /* 選択肢ボタン */
+    .choice-button {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: center;
+      padding: var(--pt-space-4) var(--pt-space-5);
+      border-radius: var(--pt-radius-xl);
+      border: 2px solid var(--pt-color-border-default);
+      background-color: var(--pt-color-surface-card);
+      color: var(--pt-color-text-primary);
+      cursor: pointer;
+      transition: all var(--pt-duration-normal) var(--pt-easing-default);
+      box-shadow: var(--pt-shadow-sm);
+    }
+    
+    .choice-button:hover:not(:disabled) {
+      border-color: var(--pt-color-gray-400);
+      background-color: var(--pt-color-surface-hovered);
+    }
+    
+    .choice-button:active:not(:disabled) {
+      transform: scale(0.95);
+    }
+    
+    .choice-button--selected {
+      background-color: var(--pt-color-gray-800);
+      border-color: var(--pt-color-gray-800);
+      color: var(--pt-color-text-inverse);
+      transform: scale(1.05);
+      box-shadow: var(--pt-shadow-lg);
+    }
+    
+    .choice-button--correct {
+      background-color: var(--pt-color-result-win-default);
+      border-color: var(--pt-color-result-win-default);
+      color: var(--pt-color-text-inverse);
+    }
+    
+    .choice-button--wrong {
+      background-color: var(--pt-color-result-lose-default);
+      border-color: var(--pt-color-result-lose-default);
+      color: var(--pt-color-text-inverse);
+    }
+    
+    .choice-button--actual {
+      background-color: var(--pt-color-surface-card);
+      border-color: var(--pt-color-result-win-default);
+      color: var(--pt-color-result-win-default);
+      box-shadow: 0 0 0 4px var(--pt-color-result-win-subtle);
+    }
+    
+    .choice-button--disabled {
+      background-color: var(--pt-color-surface-hovered);
+      border-color: var(--pt-color-border-subtle);
+      color: var(--pt-color-text-disabled);
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  `],
 })
 export class QuizComponent implements OnInit {
   currentPokemon = signal<Pokemon | null>(null);
@@ -145,18 +276,23 @@ export class QuizComponent implements OnInit {
 
   getChoiceButtonClass(choice: number) {
     const isSelected = this.selectedChoice() === choice;
-    const base = 'flex flex-row items-baseline justify-center px-4 py-5 rounded-2xl transition-all shadow-sm border-2 cursor-pointer active:scale-95';
+    const classes = ['choice-button'];
 
     if (this.isChecked()) {
       const isActual = this.actualEffectiveness() === choice;
-      if (isSelected && isActual) return `${base} bg-secondary border-secondary text-white shadow-secondary/20`;
-      if (isSelected && !isActual) return `${base} bg-danger border-danger text-white shadow-danger/20`;
-      if (isActual) return `${base} bg-white border-secondary text-secondary ring-4 ring-secondary/10`;
-      return `${base} bg-slate-50 border-slate-100 text-slate-300 opacity-50`;
+      if (isSelected && isActual) {
+        classes.push('choice-button--correct');
+      } else if (isSelected && !isActual) {
+        classes.push('choice-button--wrong');
+      } else if (isActual) {
+        classes.push('choice-button--actual');
+      } else {
+        classes.push('choice-button--disabled');
+      }
+    } else if (isSelected) {
+      classes.push('choice-button--selected');
     }
 
-    return isSelected
-      ? `${base} bg-primary border-primary text-white scale-105 shadow-lg shadow-primary/20`
-      : `${base} bg-white border-slate-100 text-slate-700 hover:border-primary/50 hover:bg-slate-50`;
+    return classes.join(' ');
   }
 }

--- a/src/app/ui/pt-grid/pt-grid.html
+++ b/src/app/ui/pt-grid/pt-grid.html
@@ -1,0 +1,9 @@
+<div class="pt-grid" [class.pt-grid--cols-1]="columns === 1" [class.pt-grid--cols-2]="columns === 2"
+	[class.pt-grid--cols-3]="columns === 3" [class.pt-grid--cols-4]="columns === 4"
+	[class.pt-grid--cols-6]="columns === 6" [class.pt-grid--sm-cols-1]="smColumns === 1"
+	[class.pt-grid--sm-cols-2]="smColumns === 2" [class.pt-grid--sm-cols-3]="smColumns === 3"
+	[class.pt-grid--sm-cols-4]="smColumns === 4" [class.pt-grid--sm-cols-6]="smColumns === 6"
+	[class.pt-grid--gap-none]="gap === 'none'" [class.pt-grid--gap-sm]="gap === 'sm'"
+	[class.pt-grid--gap-md]="gap === 'md'" [class.pt-grid--gap-lg]="gap === 'lg'">
+	<ng-content></ng-content>
+</div>

--- a/src/app/ui/pt-grid/pt-grid.scss
+++ b/src/app/ui/pt-grid/pt-grid.scss
@@ -1,0 +1,69 @@
+/**
+ * @what Grid component styles - CSS Grid layout primitive
+ * @why Provide consistent grid layouts via Design Tokens
+ */
+
+.pt-grid {
+	display: grid;
+
+	// Column variants (default/mobile)
+	&--cols-1 {
+		grid-template-columns: repeat(1, minmax(0, 1fr));
+	}
+
+	&--cols-2 {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	&--cols-3 {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	&--cols-4 {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	&--cols-6 {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+	}
+
+	// Column variants at sm breakpoint (640px+)
+	@media (width >=40rem) {
+		&--sm-cols-1 {
+			grid-template-columns: repeat(1, minmax(0, 1fr));
+		}
+
+		&--sm-cols-2 {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		&--sm-cols-3 {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+
+		&--sm-cols-4 {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
+		}
+
+		&--sm-cols-6 {
+			grid-template-columns: repeat(6, minmax(0, 1fr));
+		}
+	}
+
+	// Gap variants
+	&--gap-none {
+		gap: var(--pt-grid-gap-none);
+	}
+
+	&--gap-sm {
+		gap: var(--pt-grid-gap-sm);
+	}
+
+	&--gap-md {
+		gap: var(--pt-grid-gap-md);
+	}
+
+	&--gap-lg {
+		gap: var(--pt-grid-gap-lg);
+	}
+}

--- a/src/app/ui/pt-grid/pt-grid.spec.ts
+++ b/src/app/ui/pt-grid/pt-grid.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * GridComponent Unit Tests
+ *
+ * @phase Phase 3: Component and Integration Testing
+ * @blocker Current `vitest.config.ts` uses `environment: 'node'`.
+ *          Importing Angular components triggers JIT compilation requirements.
+ *          Requires proper Angular test setup (TestBed, @angular/compiler).
+ *
+ * @todo When Phase 3 is ready:
+ *       1. Configure vitest with jsdom or Angular-specific environment
+ *       2. Set up @angular/platform-browser-dynamic for JIT
+ *       3. Restore TestBed-based component tests
+ */
+
+describe('GridComponent', () => {
+	it.todo('should create');
+
+	describe('Columns', () => {
+		it.todo('should apply 2 columns by default');
+		it.todo('should apply 1 column');
+		it.todo('should apply 3 columns');
+		it.todo('should apply 4 columns');
+		it.todo('should apply 6 columns');
+	});
+
+	describe('Responsive Columns (sm breakpoint)', () => {
+		it.todo('should not apply sm columns if not set');
+		it.todo('should apply sm-cols-1 at sm breakpoint');
+		it.todo('should apply sm-cols-3 at sm breakpoint');
+	});
+
+	describe('Gap', () => {
+		it.todo('should apply md gap by default');
+		it.todo('should apply none gap');
+		it.todo('should apply sm gap');
+		it.todo('should apply lg gap');
+	});
+});

--- a/src/app/ui/pt-grid/pt-grid.ts
+++ b/src/app/ui/pt-grid/pt-grid.ts
@@ -1,0 +1,49 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/** Grid column count options */
+type GridColumns = 1 | 2 | 3 | 4 | 6;
+
+/** Grid gap size options */
+type GridGap = 'none' | 'sm' | 'md' | 'lg';
+
+/**
+ * Grid component for CSS Grid-based layouts
+ *
+ * @example
+ * <pt-grid [columns]="2" [smColumns]="3" gap="md">
+ *   <button *ngFor="let choice of choices">...</button>
+ * </pt-grid>
+ *
+ * @reference
+ * - CSS Grid Layout: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout
+ */
+@Component({
+	selector: 'pt-grid',
+	standalone: true,
+	imports: [CommonModule],
+	templateUrl: './pt-grid.html',
+	styleUrls: ['./pt-grid.scss'],
+})
+export class GridComponent {
+	/** Default column count */
+	private static readonly DEFAULT_COLUMNS: GridColumns = 2;
+
+	/**
+	 * Number of columns (default/mobile)
+	 * @default 2
+	 */
+	@Input() columns: GridColumns = GridComponent.DEFAULT_COLUMNS;
+
+	/**
+	 * Number of columns on sm breakpoint (640px+)
+	 * If not set, uses columns value
+	 */
+	@Input() smColumns?: GridColumns;
+
+	/**
+	 * Gap between grid items
+	 * @default 'md'
+	 */
+	@Input() gap: GridGap = 'md';
+}

--- a/src/app/ui/pt-stack/pt-stack.html
+++ b/src/app/ui/pt-stack/pt-stack.html
@@ -1,0 +1,11 @@
+<div class="pt-stack" [class.pt-stack--vertical]="direction === 'vertical'"
+	[class.pt-stack--horizontal]="direction === 'horizontal'" [class.pt-stack--responsive]="direction === 'responsive'"
+	[class.pt-stack--gap-none]="gap === 'none'" [class.pt-stack--gap-xs]="gap === 'xs'"
+	[class.pt-stack--gap-sm]="gap === 'sm'" [class.pt-stack--gap-md]="gap === 'md'"
+	[class.pt-stack--gap-lg]="gap === 'lg'" [class.pt-stack--gap-xl]="gap === 'xl'"
+	[class.pt-stack--align-start]="align === 'start'" [class.pt-stack--align-center]="align === 'center'"
+	[class.pt-stack--align-end]="align === 'end'" [class.pt-stack--align-stretch]="align === 'stretch'"
+	[class.pt-stack--justify-start]="justify === 'start'" [class.pt-stack--justify-center]="justify === 'center'"
+	[class.pt-stack--justify-end]="justify === 'end'" [class.pt-stack--justify-between]="justify === 'between'">
+	<ng-content></ng-content>
+</div>

--- a/src/app/ui/pt-stack/pt-stack.scss
+++ b/src/app/ui/pt-stack/pt-stack.scss
@@ -1,0 +1,84 @@
+/**
+ * @what Stack component styles - Flexbox layout primitive
+ * @why Provide consistent spacing and alignment via Design Tokens
+ */
+
+.pt-stack {
+	display: flex;
+
+	// Direction variants
+	&--vertical {
+		flex-direction: column;
+	}
+
+	&--horizontal {
+		flex-direction: row;
+	}
+
+	&--responsive {
+		flex-direction: column;
+
+		@media (width >=40rem) {
+			flex-direction: row;
+		}
+	}
+
+	// Gap variants
+	&--gap-none {
+		gap: var(--pt-stack-gap-none);
+	}
+
+	&--gap-xs {
+		gap: var(--pt-stack-gap-xs);
+	}
+
+	&--gap-sm {
+		gap: var(--pt-stack-gap-sm);
+	}
+
+	&--gap-md {
+		gap: var(--pt-stack-gap-md);
+	}
+
+	&--gap-lg {
+		gap: var(--pt-stack-gap-lg);
+	}
+
+	&--gap-xl {
+		gap: var(--pt-stack-gap-xl);
+	}
+
+	// Align variants (cross axis)
+	&--align-start {
+		align-items: flex-start;
+	}
+
+	&--align-center {
+		align-items: center;
+	}
+
+	&--align-end {
+		align-items: flex-end;
+	}
+
+	&--align-stretch {
+		align-items: stretch;
+	}
+
+	// Justify variants (main axis)
+	&--justify-start {
+		justify-content: flex-start;
+	}
+
+	&--justify-center {
+		justify-content: center;
+	}
+
+	&--justify-end {
+		justify-content: flex-end;
+	}
+
+	&--justify-between {
+		justify-content: space-between;
+	}
+}

--- a/src/app/ui/pt-stack/pt-stack.spec.ts
+++ b/src/app/ui/pt-stack/pt-stack.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * StackComponent Unit Tests
+ *
+ * @phase Phase 3: Component and Integration Testing
+ * @blocker Current `vitest.config.ts` uses `environment: 'node'`.
+ *          Importing Angular components triggers JIT compilation requirements.
+ *          Requires proper Angular test setup (TestBed, @angular/compiler).
+ *
+ * @todo When Phase 3 is ready:
+ *       1. Configure vitest with jsdom or Angular-specific environment
+ *       2. Set up @angular/platform-browser-dynamic for JIT
+ *       3. Restore TestBed-based component tests
+ */
+
+describe('StackComponent', () => {
+	it.todo('should create');
+
+	describe('Direction', () => {
+		it.todo('should apply vertical direction by default');
+		it.todo('should apply horizontal direction');
+		it.todo('should apply responsive direction');
+	});
+
+	describe('Gap', () => {
+		it.todo('should apply md gap by default');
+		it.todo('should apply none gap');
+		it.todo('should apply xs gap');
+		it.todo('should apply sm gap');
+		it.todo('should apply lg gap');
+		it.todo('should apply xl gap');
+	});
+
+	describe('Align', () => {
+		it.todo('should apply stretch align by default');
+		it.todo('should apply start align');
+		it.todo('should apply center align');
+		it.todo('should apply end align');
+	});
+
+	describe('Justify', () => {
+		it.todo('should apply start justify by default');
+		it.todo('should apply center justify');
+		it.todo('should apply end justify');
+		it.todo('should apply between justify');
+	});
+});

--- a/src/app/ui/pt-stack/pt-stack.ts
+++ b/src/app/ui/pt-stack/pt-stack.ts
@@ -1,0 +1,51 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Stack component for flexbox-based layouts
+ *
+ * @example
+ * <pt-stack direction="vertical" gap="lg" align="center">
+ *   <pt-avatar ...></pt-avatar>
+ *   <h2>ピカチュウ</h2>
+ * </pt-stack>
+ *
+ * @reference
+ * - Chakra UI Stack: https://chakra-ui.com/docs/components/stack
+ * - Material UI Stack: https://mui.com/material-ui/react-stack/
+ */
+@Component({
+	selector: 'pt-stack',
+	standalone: true,
+	imports: [CommonModule],
+	templateUrl: './pt-stack.html',
+	styleUrls: ['./pt-stack.scss'],
+})
+export class StackComponent {
+	/**
+	 * Stacking direction
+	 * - vertical: column
+	 * - horizontal: row
+	 * - responsive: column on mobile, row on sm+
+	 * @default 'vertical'
+	 */
+	@Input() direction: 'vertical' | 'horizontal' | 'responsive' = 'vertical';
+
+	/**
+	 * Gap between items
+	 * @default 'md'
+	 */
+	@Input() gap: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
+
+	/**
+	 * Align items on cross axis
+	 * @default 'stretch'
+	 */
+	@Input() align: 'start' | 'center' | 'end' | 'stretch' = 'stretch';
+
+	/**
+	 * Justify content on main axis
+	 * @default 'start'
+	 */
+	@Input() justify: 'start' | 'center' | 'end' | 'between' = 'start';
+}

--- a/src/app/ui/pt-surface/pt-surface.html
+++ b/src/app/ui/pt-surface/pt-surface.html
@@ -1,0 +1,10 @@
+<div class="pt-surface" [class.pt-surface--default]="variant === 'default'"
+	[class.pt-surface--subtle]="variant === 'subtle'" [class.pt-surface--card]="variant === 'card'"
+	[class.pt-surface--ghost]="variant === 'ghost'" [class.pt-surface--padding-none]="padding === 'none'"
+	[class.pt-surface--padding-sm]="padding === 'sm'" [class.pt-surface--padding-md]="padding === 'md'"
+	[class.pt-surface--padding-lg]="padding === 'lg'" [class.pt-surface--radius-none]="radius === 'none'"
+	[class.pt-surface--radius-sm]="radius === 'sm'" [class.pt-surface--radius-md]="radius === 'md'"
+	[class.pt-surface--radius-lg]="radius === 'lg'" [class.pt-surface--radius-xl]="radius === 'xl'"
+	[class.pt-surface--radius-full]="radius === 'full'" [class.pt-surface--border]="border">
+	<ng-content></ng-content>
+</div>

--- a/src/app/ui/pt-surface/pt-surface.scss
+++ b/src/app/ui/pt-surface/pt-surface.scss
@@ -1,0 +1,76 @@
+/**
+ * @what Surface component styles - Container styling primitive
+ * @why Provide consistent container appearance via Design Tokens
+ */
+
+.pt-surface {
+	display: block;
+
+	// Variant: default (white background)
+	&--default {
+		background-color: var(--pt-color-surface);
+	}
+
+	// Variant: subtle (light gray)
+	&--subtle {
+		background-color: var(--pt-color-surface-subtle, rgb(248 250 252 / 50%));
+	}
+
+	// Variant: card (white with shadow)
+	&--card {
+		background-color: var(--pt-color-surface);
+		box-shadow: var(--pt-shadow-sm, 0 1px 2px 0 rgb(0 0 0 / 5%));
+	}
+
+	// Variant: ghost (transparent)
+	&--ghost {
+		background-color: transparent;
+	}
+
+	// Padding variants
+	&--padding-none {
+		padding: var(--pt-surface-padding-none);
+	}
+
+	&--padding-sm {
+		padding: var(--pt-surface-padding-sm);
+	}
+
+	&--padding-md {
+		padding: var(--pt-surface-padding-md);
+	}
+
+	&--padding-lg {
+		padding: var(--pt-surface-padding-lg);
+	}
+
+	// Radius variants
+	&--radius-none {
+		border-radius: var(--pt-surface-radius-none);
+	}
+
+	&--radius-sm {
+		border-radius: var(--pt-surface-radius-sm);
+	}
+
+	&--radius-md {
+		border-radius: var(--pt-surface-radius-md);
+	}
+
+	&--radius-lg {
+		border-radius: var(--pt-surface-radius-lg);
+	}
+
+	&--radius-xl {
+		border-radius: var(--pt-surface-radius-xl);
+	}
+
+	&--radius-full {
+		border-radius: var(--pt-surface-radius-full);
+	}
+
+	// Border
+	&--border {
+		border: var(--pt-surface-border-width) solid var(--pt-surface-border-color);
+	}
+}

--- a/src/app/ui/pt-surface/pt-surface.spec.ts
+++ b/src/app/ui/pt-surface/pt-surface.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * SurfaceComponent Unit Tests
+ *
+ * @phase Phase 3: Component and Integration Testing
+ * @blocker Current `vitest.config.ts` uses `environment: 'node'`.
+ *          Importing Angular components triggers JIT compilation requirements.
+ *          Requires proper Angular test setup (TestBed, @angular/compiler).
+ *
+ * @todo When Phase 3 is ready:
+ *       1. Configure vitest with jsdom or Angular-specific environment
+ *       2. Set up @angular/platform-browser-dynamic for JIT
+ *       3. Restore TestBed-based component tests
+ */
+
+describe('SurfaceComponent', () => {
+	it.todo('should create');
+
+	describe('Variant', () => {
+		it.todo('should apply default variant by default');
+		it.todo('should apply subtle variant');
+		it.todo('should apply card variant');
+		it.todo('should apply ghost variant');
+	});
+
+	describe('Padding', () => {
+		it.todo('should apply md padding by default');
+		it.todo('should apply none padding');
+		it.todo('should apply sm padding');
+		it.todo('should apply lg padding');
+	});
+
+	describe('Radius', () => {
+		it.todo('should apply md radius by default');
+		it.todo('should apply none radius');
+		it.todo('should apply sm radius');
+		it.todo('should apply lg radius');
+		it.todo('should apply xl radius');
+		it.todo('should apply full radius');
+	});
+
+	describe('Border', () => {
+		it.todo('should not have border by default');
+		it.todo('should apply border when border=true');
+	});
+});

--- a/src/app/ui/pt-surface/pt-surface.ts
+++ b/src/app/ui/pt-surface/pt-surface.ts
@@ -1,0 +1,51 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Surface component for container styling (background, border, radius, padding)
+ *
+ * @example
+ * <pt-surface variant="subtle" padding="lg" radius="xl">
+ *   <!-- content -->
+ * </pt-surface>
+ *
+ * @reference
+ * - Material UI Paper: https://mui.com/material-ui/react-paper/
+ * - Radix UI Box: https://www.radix-ui.com/primitives
+ */
+@Component({
+	selector: 'pt-surface',
+	standalone: true,
+	imports: [CommonModule],
+	templateUrl: './pt-surface.html',
+	styleUrls: ['./pt-surface.scss'],
+})
+export class SurfaceComponent {
+	/**
+	 * Visual variant
+	 * - default: white background
+	 * - subtle: light gray background
+	 * - card: white with shadow
+	 * - ghost: transparent
+	 * @default 'default'
+	 */
+	@Input() variant: 'default' | 'subtle' | 'card' | 'ghost' = 'default';
+
+	/**
+	 * Inner padding
+	 * @default 'md'
+	 */
+	@Input() padding: 'none' | 'sm' | 'md' | 'lg' = 'md';
+
+	/**
+	 * Border radius
+	 * @default 'md'
+	 */
+	@Input() radius: 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full' = 'md';
+
+	/**
+	 * Show border
+	 * @default false
+	 */
+	@Input() border = false;
+}

--- a/src/design-system/tokens/effects.ts
+++ b/src/design-system/tokens/effects.ts
@@ -54,6 +54,7 @@ export const effects = {
       "sm": "0.25rem",
       "md": "0.5rem",
       "lg": "0.75rem",
+      "xl": "1rem",
       "pill": "9999px"
     },
     "width": {

--- a/src/design-system/tokens/spacing.ts
+++ b/src/design-system/tokens/spacing.ts
@@ -35,7 +35,8 @@ export const spacing = {
       "xs": "0.25rem",
       "sm": "0.5rem",
       "md": "1rem",
-      "lg": "1.5rem"
+      "lg": "1.5rem",
+      "xl": "2rem"
     }
   }
 } as const;

--- a/src/styles/generated/_tokens.scss
+++ b/src/styles/generated/_tokens.scss
@@ -303,7 +303,16 @@ $pt-button-ghost-bg-default: rgba(0, 0, 0, 0); // 背景色。完全透明。
 $pt-button-ghost-bg-disabled: rgba(0, 0, 0, 0); // 無効時の背景色。透明のまま。
 $pt-button-ghost-border-default: rgba(0, 0, 0, 0); // 枠線色。Ghostは枠なし。
 $pt-button-danger-border-default: rgba(0, 0, 0, 0); // 枠線色。Dangerは枠なし。
+$pt-grid-columns-1: 1; // 1カラム。モバイルでの単一カラム表示。
+$pt-grid-columns-2: 2; // 2カラム。選択肢表示のデフォルト。
+$pt-grid-columns-3: 3; // 3カラム。sm以上での選択肢表示。
+$pt-grid-columns-4: 4; // 4カラム。ギャラリー表示など。
+$pt-grid-columns-6: 6; // 6カラム。高密度レイアウト。
+$pt-grid-gap-none: 0; // ギャップなし。
 $pt-heading-accent-width: 6px; // アクセントバーの幅。視覚的なアクセントとしては十分かつ控えめなサイズ。
+$pt-stack-gap-none: 0; // ギャップなし。要素同士を密着させる場合に使用。
+$pt-surface-variant-ghost-background: rgba(0, 0, 0, 0); // 透明背景。親要素の背景を透過。
+$pt-surface-padding-none: 0; // パディングなし。
 $pt-color-pokemon-type-normal: $pt-color-pokemon-normal-500; // 【用途】ノーマルタイプのバッジ・アイコン背景。
 $pt-color-pokemon-type-fire: $pt-color-pokemon-fire-500; // 【用途】ほのおタイプのバッジ・アイコン背景。
 $pt-color-pokemon-type-water: $pt-color-pokemon-water-500; // 【用途】みずタイプのバッジ・アイコン背景。
@@ -385,6 +394,7 @@ $pt-semantic-border-radius-none: $pt-radius-none; // 【用途】角丸なし。
 $pt-semantic-border-radius-sm: $pt-radius-sm; // 【用途】小さい要素。バッジ、チップ。
 $pt-semantic-border-radius-md: $pt-radius-md; // 【用途】標準要素。ボタン、入力欄。
 $pt-semantic-border-radius-lg: $pt-radius-lg; // 【用途】大きな要素。カード、パネル。
+$pt-semantic-border-radius-xl: $pt-radius-xl; // 【用途】特大コンテナ。モーダル、大きなサーフェス。
 $pt-semantic-border-radius-pill: $pt-radius-full; // 【用途】ピル形状。タグ、ステータスバッジ。
 $pt-motion-duration-instant: $pt-duration-fast; // 【用途】マイクロインタラクション。hover時の色変化等。
 $pt-motion-duration-quick: $pt-duration-normal; // 【用途】通常のトランジション。ボタン、リンク。
@@ -404,6 +414,7 @@ $pt-spacing-gap-xs: $pt-space-1; // 隣接要素間の距離を表す。イン�
 $pt-spacing-gap-sm: $pt-space-2; // 隣接要素間の距離を表す。タグリスト、小さなボタン群の間隔。
 $pt-spacing-gap-md: $pt-space-4; // 隣接要素間の距離を表す。デフォルトのグリッドギャップ。カードリスト。
 $pt-spacing-gap-lg: $pt-space-6; // 隣接要素間の距離を表す。セクション内のカード間など広い間隔。
+$pt-spacing-gap-xl: $pt-space-8; // 隣接要素間の距離を表す。セクション間の明確な分割など特大の間隔。
 $pt-typography-heading-xl-font-family: $pt-font-family-sans;
 $pt-typography-heading-xl-font-size: $pt-font-size-4xl;
 $pt-typography-heading-xl-font-weight: $pt-font-weight-bold;
@@ -463,6 +474,7 @@ $pt-heading-accent-height: $pt-space-6; // アクセントバーの高さ。テ�
 $pt-heading-accent-radius: $pt-radius-full; // アクセントバーの角丸。pill形状にする。
 $pt-heading-accent-gap: $pt-space-2; // アクセントバーとテキスト間のギャップ。
 $pt-heading-accent-color: $pt-color-gray-800; // アクセントバーの色。プライマリカラー（ボタンと同じ）。
+$pt-surface-border-width: $pt-semantic-border-width-default; // ボーダー幅。
 $pt-badge-neutral-bg: $pt-color-surface-hovered; // バッジの背景色。`background-color`に適用。
 $pt-badge-neutral-text: $pt-color-text-primary; // バッジのラベル色。`color`に適用。
 $pt-badge-win-bg: $pt-color-result-win-subtle; // 正解バッジの背景色。薄いライム。
@@ -502,4 +514,26 @@ $pt-card-padding-sm: $pt-spacing-content-sm; // paddingプロパティに適用�
 $pt-card-padding-md: $pt-spacing-content-md; // paddingプロパティに適用。カードコンポーネント専用。デフォルトの内部余白。
 $pt-card-padding-lg: $pt-spacing-content-lg; // paddingプロパティに適用。カードコンポーネント専用。広々とした内部余白。
 $pt-card-radius: $pt-semantic-border-radius-lg; // border-radiusプロパティに適用。カードコンポーネント専用。overflow: hiddenとセットで使用。
+$pt-grid-gap-sm: $pt-spacing-gap-sm; // 小ギャップ。コンパクトなグリッド。
+$pt-grid-gap-md: $pt-spacing-gap-md; // 中ギャップ。標準グリッド。デフォルト値。
+$pt-grid-gap-lg: $pt-spacing-gap-lg; // 大ギャップ。ゆったりしたグリッド。
 $pt-heading-text-color: $pt-color-text-primary; // 見出しテキストの色
+$pt-stack-gap-xs: $pt-spacing-gap-xs; // 極小ギャップ。アイコンとラベルなど密接な要素間。
+$pt-stack-gap-sm: $pt-spacing-gap-sm; // 小ギャップ。関連性の高い要素間。
+$pt-stack-gap-md: $pt-spacing-gap-md; // 中ギャップ。標準的な要素間。デフォルト値。
+$pt-stack-gap-lg: $pt-spacing-gap-lg; // 大ギャップ。セクション内の区切り。
+$pt-stack-gap-xl: $pt-spacing-gap-xl; // 特大ギャップ。セクション間の明確な分割。
+$pt-surface-variant-default-background: $pt-color-surface-card; // デフォルト背景。白色ベース。
+$pt-surface-variant-subtle-background: $pt-color-surface-page; // 控えめな背景。セクション区分けに使用。
+$pt-surface-variant-card-background: $pt-color-surface-card; // カード背景。elevationと併用。
+$pt-surface-variant-card-elevation: $pt-elevation-raised; // カードの影。軽く浮いた状態。
+$pt-surface-padding-sm: $pt-spacing-content-sm; // 小パディング。コンパクトなコンテナ。
+$pt-surface-padding-md: $pt-spacing-content-md; // 中パディング。標準的なコンテナ。デフォルト値。
+$pt-surface-padding-lg: $pt-spacing-content-lg; // 大パディング。ゆったりしたコンテナ。
+$pt-surface-radius-none: $pt-semantic-border-radius-none; // 角丸なし。
+$pt-surface-radius-sm: $pt-semantic-border-radius-sm; // 小角丸。
+$pt-surface-radius-md: $pt-semantic-border-radius-md; // 中角丸。デフォルト値。
+$pt-surface-radius-lg: $pt-semantic-border-radius-lg; // 大角丸。
+$pt-surface-radius-xl: $pt-semantic-border-radius-xl; // 特大角丸。大きなコンテナやモーダル。
+$pt-surface-radius-full: $pt-semantic-border-radius-pill; // 完全円形/ピル形状。
+$pt-surface-border-color: $pt-color-border-default; // ボーダー色。

--- a/src/styles/generated/tokens.css
+++ b/src/styles/generated/tokens.css
@@ -305,7 +305,16 @@
   --pt-button-ghost-bg-disabled: rgba(0, 0, 0, 0); /** 無効時の背景色。透明のまま。 */
   --pt-button-ghost-border-default: rgba(0, 0, 0, 0); /** 枠線色。Ghostは枠なし。 */
   --pt-button-danger-border-default: rgba(0, 0, 0, 0); /** 枠線色。Dangerは枠なし。 */
+  --pt-grid-columns-1: 1; /** 1カラム。モバイルでの単一カラム表示。 */
+  --pt-grid-columns-2: 2; /** 2カラム。選択肢表示のデフォルト。 */
+  --pt-grid-columns-3: 3; /** 3カラム。sm以上での選択肢表示。 */
+  --pt-grid-columns-4: 4; /** 4カラム。ギャラリー表示など。 */
+  --pt-grid-columns-6: 6; /** 6カラム。高密度レイアウト。 */
+  --pt-grid-gap-none: 0; /** ギャップなし。 */
   --pt-heading-accent-width: 6px; /** アクセントバーの幅。視覚的なアクセントとしては十分かつ控えめなサイズ。 */
+  --pt-stack-gap-none: 0; /** ギャップなし。要素同士を密着させる場合に使用。 */
+  --pt-surface-variant-ghost-background: rgba(0, 0, 0, 0); /** 透明背景。親要素の背景を透過。 */
+  --pt-surface-padding-none: 0; /** パディングなし。 */
   --pt-color-pokemon-type-normal: var(--pt-color-pokemon-normal-500); /** 【用途】ノーマルタイプのバッジ・アイコン背景。 */
   --pt-color-pokemon-type-fire: var(--pt-color-pokemon-fire-500); /** 【用途】ほのおタイプのバッジ・アイコン背景。 */
   --pt-color-pokemon-type-water: var(--pt-color-pokemon-water-500); /** 【用途】みずタイプのバッジ・アイコン背景。 */
@@ -387,6 +396,7 @@
   --pt-semantic-border-radius-sm: var(--pt-radius-sm); /** 【用途】小さい要素。バッジ、チップ。 */
   --pt-semantic-border-radius-md: var(--pt-radius-md); /** 【用途】標準要素。ボタン、入力欄。 */
   --pt-semantic-border-radius-lg: var(--pt-radius-lg); /** 【用途】大きな要素。カード、パネル。 */
+  --pt-semantic-border-radius-xl: var(--pt-radius-xl); /** 【用途】特大コンテナ。モーダル、大きなサーフェス。 */
   --pt-semantic-border-radius-pill: var(--pt-radius-full); /** 【用途】ピル形状。タグ、ステータスバッジ。 */
   --pt-motion-duration-instant: var(--pt-duration-fast); /** 【用途】マイクロインタラクション。hover時の色変化等。 */
   --pt-motion-duration-quick: var(--pt-duration-normal); /** 【用途】通常のトランジション。ボタン、リンク。 */
@@ -406,6 +416,7 @@
   --pt-spacing-gap-sm: var(--pt-space-2); /** 隣接要素間の距離を表す。タグリスト、小さなボタン群の間隔。 */
   --pt-spacing-gap-md: var(--pt-space-4); /** 隣接要素間の距離を表す。デフォルトのグリッドギャップ。カードリスト。 */
   --pt-spacing-gap-lg: var(--pt-space-6); /** 隣接要素間の距離を表す。セクション内のカード間など広い間隔。 */
+  --pt-spacing-gap-xl: var(--pt-space-8); /** 隣接要素間の距離を表す。セクション間の明確な分割など特大の間隔。 */
   --pt-typography-heading-xl-font-family: var(--pt-font-family-sans);
   --pt-typography-heading-xl-font-size: var(--pt-font-size-4xl);
   --pt-typography-heading-xl-font-weight: var(--pt-font-weight-bold);
@@ -465,6 +476,7 @@
   --pt-heading-accent-radius: var(--pt-radius-full); /** アクセントバーの角丸。pill形状にする。 */
   --pt-heading-accent-gap: var(--pt-space-2); /** アクセントバーとテキスト間のギャップ。 */
   --pt-heading-accent-color: var(--pt-color-gray-800); /** アクセントバーの色。プライマリカラー（ボタンと同じ）。 */
+  --pt-surface-border-width: var(--pt-semantic-border-width-default); /** ボーダー幅。 */
   --pt-badge-neutral-bg: var(--pt-color-surface-hovered); /** バッジの背景色。`background-color`に適用。 */
   --pt-badge-neutral-text: var(--pt-color-text-primary); /** バッジのラベル色。`color`に適用。 */
   --pt-badge-win-bg: var(--pt-color-result-win-subtle); /** 正解バッジの背景色。薄いライム。 */
@@ -504,5 +516,27 @@
   --pt-card-padding-md: var(--pt-spacing-content-md); /** paddingプロパティに適用。カードコンポーネント専用。デフォルトの内部余白。 */
   --pt-card-padding-lg: var(--pt-spacing-content-lg); /** paddingプロパティに適用。カードコンポーネント専用。広々とした内部余白。 */
   --pt-card-radius: var(--pt-semantic-border-radius-lg); /** border-radiusプロパティに適用。カードコンポーネント専用。overflow: hiddenとセットで使用。 */
+  --pt-grid-gap-sm: var(--pt-spacing-gap-sm); /** 小ギャップ。コンパクトなグリッド。 */
+  --pt-grid-gap-md: var(--pt-spacing-gap-md); /** 中ギャップ。標準グリッド。デフォルト値。 */
+  --pt-grid-gap-lg: var(--pt-spacing-gap-lg); /** 大ギャップ。ゆったりしたグリッド。 */
   --pt-heading-text-color: var(--pt-color-text-primary); /** 見出しテキストの色 */
+  --pt-stack-gap-xs: var(--pt-spacing-gap-xs); /** 極小ギャップ。アイコンとラベルなど密接な要素間。 */
+  --pt-stack-gap-sm: var(--pt-spacing-gap-sm); /** 小ギャップ。関連性の高い要素間。 */
+  --pt-stack-gap-md: var(--pt-spacing-gap-md); /** 中ギャップ。標準的な要素間。デフォルト値。 */
+  --pt-stack-gap-lg: var(--pt-spacing-gap-lg); /** 大ギャップ。セクション内の区切り。 */
+  --pt-stack-gap-xl: var(--pt-spacing-gap-xl); /** 特大ギャップ。セクション間の明確な分割。 */
+  --pt-surface-variant-default-background: var(--pt-color-surface-card); /** デフォルト背景。白色ベース。 */
+  --pt-surface-variant-subtle-background: var(--pt-color-surface-page); /** 控えめな背景。セクション区分けに使用。 */
+  --pt-surface-variant-card-background: var(--pt-color-surface-card); /** カード背景。elevationと併用。 */
+  --pt-surface-variant-card-elevation: var(--pt-elevation-raised); /** カードの影。軽く浮いた状態。 */
+  --pt-surface-padding-sm: var(--pt-spacing-content-sm); /** 小パディング。コンパクトなコンテナ。 */
+  --pt-surface-padding-md: var(--pt-spacing-content-md); /** 中パディング。標準的なコンテナ。デフォルト値。 */
+  --pt-surface-padding-lg: var(--pt-spacing-content-lg); /** 大パディング。ゆったりしたコンテナ。 */
+  --pt-surface-radius-none: var(--pt-semantic-border-radius-none); /** 角丸なし。 */
+  --pt-surface-radius-sm: var(--pt-semantic-border-radius-sm); /** 小角丸。 */
+  --pt-surface-radius-md: var(--pt-semantic-border-radius-md); /** 中角丸。デフォルト値。 */
+  --pt-surface-radius-lg: var(--pt-semantic-border-radius-lg); /** 大角丸。 */
+  --pt-surface-radius-xl: var(--pt-semantic-border-radius-xl); /** 特大角丸。大きなコンテナやモーダル。 */
+  --pt-surface-radius-full: var(--pt-semantic-border-radius-pill); /** 完全円形/ピル形状。 */
+  --pt-surface-border-color: var(--pt-color-border-default); /** ボーダー色。 */
 }


### PR DESCRIPTION
## 💡 概要

Phase 2-3 リファクタリング: Layout Primitives の導入と Quiz 画面の書き直し

## 📝 変更内容

### Phase 2: Layout Primitives
- `pt-stack`, `pt-surface`, `pt-grid` コンポーネントを追加
- Tier 3 component tokens を追加（stack, surface, grid）
- Tier 2/3 トークン参照を修正（「流用」やprimitive直接参照を排除）
- SCSS で primitive 直接参照ではなく component token を使用するよう修正

### Phase 3: Quiz 画面リファクタ
- 全ての Tailwind クラスを Design Tokens に置換
- Layout Primitives を使用した構造に書き直し
- ボタンスタイルを CSS クラス + Design Token 変数に移行
- インライン Tailwind スタイリングを完全に削除

## 🔗 関連Issue

Related to:
- #74 (Tailwind → Design Tokens 置換)
- #76 (pt-text + Smart/Dumb 分離 - 今後対応)

## 📷 スクリーンショット（該当する場合）

見た目の変更は最小限（Tailwindから Design Tokens への移行のため視覚的な差異はほぼなし）

## ✅ チェックリスト

- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [x] 必要に応じてドキュメントを更新した

## 📌 補足事項

残作業は Issue で管理:
- Issue #75: Quiz選択肢ボタンを pt-button 化
- Issue #76: pt-text 作成 + Smart/Dumb 分離
- Issue #77: ポケモン画像読み込み速度改善

--- 

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🐛 fix: バグ修正
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
