### PR TITLE
🩹 fix: read base href from document base tag

### DIFF
--- a/src/app/core/services/asset-path.service.ts
+++ b/src/app/core/services/asset-path.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { APP_BASE_HREF } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 
 /**
  * Asset path resolver service
@@ -27,12 +27,11 @@ export class AssetPathService {
 	private readonly baseHref: string;
 
 	constructor() {
-		// Inject APP_BASE_HREF with a fallback to '/' for development
-		try {
-			this.baseHref = inject(APP_BASE_HREF, { optional: true }) || '/';
-		} catch {
-			this.baseHref = '/';
-		}
+		// Read base href from the <base> tag in the document
+		// This is automatically set by Angular when using --base-href option
+		const doc = inject(DOCUMENT);
+		const baseElement = doc.querySelector('base');
+		this.baseHref = baseElement?.getAttribute('href') || '/';
 	}
 
 	/**


### PR DESCRIPTION
## 💡 概要
アイコンがGitHub Pagesで404になる問題の根本修正。`<base>`タグからbaseHrefを取得するように変更。

## 📝 変更内容
- **asset-path.service.ts**: `APP_BASE_HREF`トークンではなく、`DOCUMENT`から`<base>`タグを読み取ってbaseHrefを取得

## 🔗 関連Issue
<!-- 該当なし -->

## 📷 スクリーンショット（該当する場合）
該当なし

## ✅ チェックリスト
- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [ ] 必要に応じてドキュメントを更新した

## 📌 補足事項
### 問題の原因
`APP_BASE_HREF` トークンはAngularで明示的に `provide` しないと利用できない。しかし、`--base-href` オプションでビルドすると、Angularは `index.html` に `<base href="...">` タグを自動挿入する。

### 解決策
`APP_BASE_HREF` トークンを使うのではなく、`DOCUMENT` から `<base>` タグを直接読み取るように変更。これにより、すべてのAngularアプリ（メイン・docs）で正しくbaseHrefが取得される。

--- 

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🩹 fix: バグ修正
- 🐛 bug: バグ報告（Issue用）
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他
- ❓ question: 質問・議論（Issue用）
- ⏪ revert: 変更を元に戻す
- 💥 breaking: 破壊的変更
- 🚧 wip: 作業中

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集
<!-- レビュー時によく使う用語の意味 -->

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
