### PR TITLE
fix: align RadioButton border-radius with Button

### DIFF
--- a/design-tokens/tier3-component/radio-button.json
+++ b/design-tokens/tier3-component/radio-button.json
@@ -153,9 +153,9 @@
 			}
 		},
 		"radius": {
-			"value": "{semantic-border.radius.xl}",
+			"value": "{semantic-border.radius.md}",
 			"type": "borderRadius",
-			"$description": "角丸。`border-radius`に適用。大きめで柔らかい印象。"
+			"$description": "角丸。`border-radius`に適用。Buttonと統一。"
 		},
 		"borderWidth": {
 			"value": "{semantic-border.width.thick}",

--- a/src/styles/generated/_tokens.scss
+++ b/src/styles/generated/_tokens.scss
@@ -570,7 +570,7 @@ $pt-radio-button-feedback-actual-ring: $pt-color-result-win-subtle; // 正解表
 $pt-radio-button-focus-ring: $pt-color-border-focused; // フォーカスリングの色。`outline`に適用。アクセシビリティ用。
 $pt-radio-button-padding-x: $pt-spacing-content-md; // 水平方向の内側余白。`padding-inline`に適用。
 $pt-radio-button-padding-y: $pt-spacing-content-sm; // 垂直方向の内側余白。`padding-block`に適用。よりコンパクトに。
-$pt-radio-button-radius: $pt-semantic-border-radius-xl; // 角丸。`border-radius`に適用。大きめで柔らかい印象。
+$pt-radio-button-radius: $pt-semantic-border-radius-md; // 角丸。`border-radius`に適用。Buttonと統一。
 $pt-radio-button-shadow-default: $pt-elevation-raised; // デフォルト時の影。軽く浮いた印象。
 $pt-radio-button-shadow-selected: $pt-elevation-overlay; // 選択時の影。より強調された浮き上がり。
 $pt-spinner-color-primary: $pt-color-text-primary; // プライマリカラー。デフォルトのスピナー色。

--- a/src/styles/generated/tokens.css
+++ b/src/styles/generated/tokens.css
@@ -572,7 +572,7 @@
   --pt-radio-button-focus-ring: var(--pt-color-border-focused); /** フォーカスリングの色。`outline`に適用。アクセシビリティ用。 */
   --pt-radio-button-padding-x: var(--pt-spacing-content-md); /** 水平方向の内側余白。`padding-inline`に適用。 */
   --pt-radio-button-padding-y: var(--pt-spacing-content-sm); /** 垂直方向の内側余白。`padding-block`に適用。よりコンパクトに。 */
-  --pt-radio-button-radius: var(--pt-semantic-border-radius-xl); /** 角丸。`border-radius`に適用。大きめで柔らかい印象。 */
+  --pt-radio-button-radius: var(--pt-semantic-border-radius-md); /** 角丸。`border-radius`に適用。Buttonと統一。 */
   --pt-radio-button-shadow-default: var(--pt-elevation-raised); /** デフォルト時の影。軽く浮いた印象。 */
   --pt-radio-button-shadow-selected: var(--pt-elevation-overlay); /** 選択時の影。より強調された浮き上がり。 */
   --pt-spinner-color-primary: var(--pt-color-text-primary); /** プライマリカラー。デフォルトのスピナー色。 */


### PR DESCRIPTION
## 💡 概要

RadioButtonの角丸をButtonと統一し、視覚的一貫性を向上。

## 📝 変更内容

### トークン変更
- `--pt-radio-button-radius`: `radius-xl` → `radius-md`

### 理由
- ButtonとRadioButtonの視覚的スタイルを統一
- ユーザーが両コンポーネントを同じコンテキストで使用する際の違和感を解消

## 🔗 関連Issue

- Partially addresses #108

## 📷 スクリーンショット（該当する場合）

localhost:4300 で確認可能

## ✅ チェックリスト

- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [x] 必要に応じてドキュメントを更新した

## 📌 補足事項

PR #116 の追加修正。ButtonとRadioButtonの視覚的統一を完成させる。

---

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🩹 fix: バグ修正
- 🐛 bug: バグ報告（Issue用）
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他
- ❓ question: 質問・議論（Issue用）
- ⏪ revert: 変更を元に戻す
- 💥 breaking: 破壊的変更
- 🚧 wip: 作業中

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
