### PR TITLE
✨ feat(icon): add color property for icon colorization

### DIFF
--- a/docs/temp/pt-icon-color-refactor-plan.md
+++ b/docs/temp/pt-icon-color-refactor-plan.md
@@ -1,0 +1,479 @@
+---
+title: pt-icon color プロパティ追加
+status: in-progress
+created: 2026-02-03
+task: "pt-icon コンポーネントに color プロパティを追加し、タイプカラーでアイコンを着色できるようにする"
+---
+
+# pt-icon color プロパティ追加 実装計画
+
+## 概要
+
+`pt-icon` コンポーネントに `color` プロパティを追加し、タイプ名（`fire`, `water` など）または `inverse` を渡すことでアイコンを着色できるようにする。
+
+### 背景
+
+- SVG アイコンが白色（`fill: #fff`）で統一された
+- 現状では背景色がないとアイコンが見えない
+- 一般的なデザインシステムでは、アイコンに色を渡せるのが標準
+
+### ゴール
+
+```html
+<!-- タイプカラーで着色 -->
+<pt-icon src="fire.svg" color="fire"></pt-icon>
+
+<!-- 白（inverse）-->
+<pt-icon src="fire.svg" color="inverse"></pt-icon>
+
+<!-- 親の色を継承（デフォルト）-->
+<pt-icon src="fire.svg"></pt-icon>
+```
+
+---
+
+## 技術設計
+
+### 実装方式: CSS mask
+
+`<img>` タグでは SVG の色を CSS で変更できないため、`<div>` + CSS mask を使用する。
+
+```scss
+.pt-icon {
+  background-color: var(--icon-color, currentColor);
+  mask-image: var(--icon-src);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: var(--icon-src);
+  -webkit-mask-size: contain;
+}
+```
+
+### 新 API
+
+```typescript
+@Input() color?: PokemonType | 'inverse';
+
+// 変換ロジック
+get iconColor(): string | null {
+  if (!this.color) return null;
+  if (this.color === 'inverse') return 'var(--pt-color-text-inverse)';
+  return `var(--pt-color-pokemon-${this.color}-500)`;
+}
+```
+
+### 後方互換性
+
+- `color` が未指定の場合は `currentColor` を使用（親の色を継承）
+- 既存の使用箇所に影響なし
+
+---
+
+## 実装計画
+
+### Phase 0: 準備
+
+#### 0.1 ブランチ作成
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b refactor/pt-icon-color-support
+```
+
+#### 0.2 SVG 変更をコミット（完了済み）
+
+SVG アイコンは白抜き（`fill: #fff`）で統一済み。
+
+---
+
+### Phase 1: pt-icon コンポーネント改修
+
+#### 1.1 型定義の追加
+
+**ファイル:** `src/app/ui/pt-icon/pt-icon.types.ts`（新規作成）
+
+```typescript
+import { PokemonType } from '@domain/type-chart';
+
+export const ICON_SIZES = ['sm', 'md', 'lg'] as const;
+export type IconSize = (typeof ICON_SIZES)[number];
+
+export type IconColor = PokemonType | 'inverse';
+```
+
+#### 1.2 コンポーネント改修
+
+**ファイル:** `src/app/ui/pt-icon/pt-icon.ts`
+
+変更内容:
+- `IconSize`, `IconColor` 型をインポート
+- `color` input を追加
+- `iconColor` getter を追加（color → CSS 変数変換）
+- `maskImageUrl` getter を追加
+
+```typescript
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconSize, IconColor } from './pt-icon.types';
+
+@Component({
+  selector: 'pt-icon',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pt-icon.html',
+  styleUrls: ['./pt-icon.scss'],
+})
+export class IconComponent {
+  @Input({ required: true }) src!: string;
+  @Input() size: IconSize = 'md';
+  @Input() alt = '';
+  @Input() color?: IconColor;
+
+  get iconClasses(): string[] {
+    return ['pt-icon', `pt-icon--${this.size}`];
+  }
+
+  get iconColor(): string | null {
+    if (!this.color) return null;
+    if (this.color === 'inverse') return 'var(--pt-color-text-inverse)';
+    return `var(--pt-color-pokemon-${this.color}-500)`;
+  }
+
+  get maskImageUrl(): string {
+    return `url(${this.src})`;
+  }
+}
+```
+
+#### 1.3 テンプレート改修
+
+**ファイル:** `src/app/ui/pt-icon/pt-icon.html`
+
+```html
+@if (color) {
+  <!-- 着色モード: CSS mask -->
+  <div 
+    [ngClass]="iconClasses"
+    [style.background-color]="iconColor"
+    [style.mask-image]="maskImageUrl"
+    [style.-webkit-mask-image]="maskImageUrl"
+    role="img"
+    [attr.aria-label]="alt || null"
+  ></div>
+} @else {
+  <!-- 従来モード: img タグ（後方互換） -->
+  <img 
+    [src]="src" 
+    [alt]="alt" 
+    [ngClass]="iconClasses"
+  />
+}
+```
+
+#### 1.4 スタイル改修
+
+**ファイル:** `src/app/ui/pt-icon/pt-icon.scss`
+
+```scss
+/**
+ * @what Icon component styles
+ * @why Provide flexible icon display with color support using Design Tokens
+ *
+ * @tokens Tier 3: icon.json
+ */
+
+@use 'mixins/component-base' as base;
+
+:host {
+  @include base.host-image;
+}
+
+.pt-icon {
+  display: block;
+  object-fit: contain;
+
+  // CSS mask 用スタイル（color指定時）
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+
+  // Size variants
+  &--sm {
+    width: var(--pt-icon-size-sm);
+    height: var(--pt-icon-size-sm);
+  }
+
+  &--md {
+    width: var(--pt-icon-size-md);
+    height: var(--pt-icon-size-md);
+  }
+
+  &--lg {
+    width: var(--pt-icon-size-lg);
+    height: var(--pt-icon-size-lg);
+  }
+}
+```
+
+---
+
+### Phase 2: Icon デモリファクタ
+
+#### 2.1 sizes-demo.component.ts
+
+**ファイル:** `projects/docs/src/components/icon/demos/sizes-demo.component.ts`
+
+背景ラッパーを削除し、`color` プロパティを使用:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { IconComponent } from '@ui/pt-icon/pt-icon';
+import { AssetPathService } from '@app/core/services/asset-path.service';
+
+@Component({
+  selector: 'icon-sizes-demo',
+  standalone: true,
+  imports: [IconComponent],
+  template: `
+    @for (size of sizes; track size) {
+      <pt-icon [src]="iconPath" [size]="size" color="fire"></pt-icon>
+    }
+  `,
+})
+export class IconSizesDemoComponent {
+  private readonly assetPath = inject(AssetPathService);
+  readonly sizes = ['sm', 'md', 'lg'] as const;
+
+  get iconPath(): string {
+    return this.assetPath.icon('fire');
+  }
+}
+```
+
+#### 2.2 types-demo.component.ts
+
+**ファイル:** `projects/docs/src/components/icon/demos/types-demo.component.ts`
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { IconComponent } from '@ui/pt-icon/pt-icon';
+import { AssetPathService } from '@app/core/services/asset-path.service';
+import { IconColor } from '@ui/pt-icon/pt-icon.types';
+
+@Component({
+  selector: 'icon-types-demo',
+  standalone: true,
+  imports: [IconComponent],
+  template: `
+    @for (type of types; track type) {
+      <pt-icon [src]="getIconPath(type)" size="md" [color]="type"></pt-icon>
+    }
+  `,
+})
+export class IconTypesDemoComponent {
+  private readonly assetPath = inject(AssetPathService);
+  readonly types: IconColor[] = ['fire', 'water', 'grass', 'electric', 'ice', 'fighting'];
+
+  getIconPath(type: string): string {
+    return this.assetPath.icon(type);
+  }
+}
+```
+
+#### 2.3 playground.component.ts
+
+**ファイル:** `projects/docs/src/components/icon/demos/playground.component.ts`
+
+`color` プロパティを Playground に追加:
+
+```typescript
+import { Component, Input, inject } from '@angular/core';
+import { IconComponent } from '@ui/pt-icon/pt-icon';
+import { AssetPathService } from '@app/core/services/asset-path.service';
+import { IconSize, IconColor } from '@ui/pt-icon/pt-icon.types';
+import { PokemonType } from '@domain/type-chart';
+
+@Component({
+  selector: 'icon-playground',
+  standalone: true,
+  imports: [IconComponent],
+  template: `
+    <pt-icon [src]="iconPath" [size]="size" [color]="color" [alt]="alt"></pt-icon>
+  `,
+})
+export class IconPlaygroundComponent {
+  private readonly assetPath = inject(AssetPathService);
+
+  @Input() iconName: PokemonType = 'fire';
+  @Input() size: IconSize = 'md';
+  @Input() color: IconColor = 'fire';
+  @Input() alt = '';
+
+  get iconPath(): string {
+    return this.assetPath.icon(this.iconName || 'fire');
+  }
+}
+```
+
+---
+
+### Phase 3: ドキュメント更新
+
+#### 3.1 api.md
+
+**ファイル:** `projects/docs/src/components/icon/api.md`
+
+Playground の `color` プロパティが自動的に表示される。
+
+#### 3.2 examples.md
+
+**ファイル:** `projects/docs/src/components/icon/examples.md`
+
+着色の例を追加:
+
+```markdown
+## Colored Icons
+
+タイプカラーで着色したアイコン：
+
+{{ NgDocActions.demo("IconTypesDemoComponent") }}
+```
+
+---
+
+### Phase 4: 影響確認
+
+#### 4.1 pt-type-chip 確認
+
+`pt-type-chip` は `pt-chip` 経由でアイコンを使用。
+背景色があるため `color="inverse"` を使用するよう修正が必要な可能性あり。
+
+#### 4.2 pt-chip 確認
+
+アイコンに色を渡す機能が必要か確認。
+
+---
+
+### Phase 5: 検証
+
+#### 5.1 ローカル検証
+
+```bash
+npm run lint:css && npm run lint && npm test && npm run build
+```
+
+#### 5.2 ガードレール検証
+
+```bash
+npm run guards:validate
+```
+
+#### 5.3 NgDoc ビルド確認
+
+```bash
+npm run docs:build
+```
+
+#### 5.4 動作確認
+
+```bash
+npm run docs:serve -- --port 4300
+```
+
+http://localhost:4300/#/components/icon/examples でデモを確認。
+
+---
+
+### Phase 6: PR作成・マージ
+
+#### 6.1 コミット
+
+```bash
+git add src/app/ui/pt-icon projects/docs/src/components/icon
+git commit -m "feat(icon): add color property for icon colorization"
+git push origin refactor/pt-icon-color-support
+```
+
+#### 6.2 PR作成
+
+```bash
+node -e "const { spawnSync } = require('child_process'); const emoji = JSON.parse(require('fs').readFileSync('.agent/emoji-prefixes.json', 'utf8')).prefixes.feat; const title = emoji + ' feat(icon): add color property for icon colorization'; spawnSync('gh', ['pr', 'create', '--title', title, '--body-file', 'pr-body.md'], { stdio: 'inherit' });"
+```
+
+#### 6.3 CI確認・マージ
+
+```bash
+gh pr checks
+gh pr merge --squash --delete-branch
+```
+
+---
+
+## チェックリスト
+
+### Phase 0: 準備
+- [ ] ブランチ作成 `refactor/pt-icon-color-support`
+- [ ] SVG 変更コミット済み
+
+### Phase 1: コンポーネント改修
+- [ ] `pt-icon.types.ts` 作成
+- [ ] `pt-icon.ts` に `color` input 追加
+- [ ] `pt-icon.html` を条件分岐で改修
+- [ ] `pt-icon.scss` に CSS mask スタイル追加
+
+### Phase 2: デモリファクタ
+- [ ] `sizes-demo.component.ts` - 背景削除、color 使用
+- [ ] `types-demo.component.ts` - 背景削除、color 使用
+- [ ] `playground.component.ts` - color 追加
+
+### Phase 3: ドキュメント
+- [ ] `examples.md` 更新
+
+### Phase 4: 影響確認
+- [ ] `pt-type-chip` 動作確認
+- [ ] `pt-chip` 動作確認
+
+### Phase 5: 検証
+- [ ] `npm run lint:css` パス
+- [ ] `npm run lint` パス
+- [ ] `npm test` パス
+- [ ] `npm run build` パス
+- [ ] `npm run guards:validate` パス
+- [ ] `npm run docs:build` パス
+- [ ] 動作確認（localhost:4300）
+
+### Phase 6: PR
+- [ ] コミット
+- [ ] プッシュ
+- [ ] PR作成
+- [ ] CI確認
+- [ ] マージ（ユーザーがOKと言ったら）
+
+---
+
+## 工数見積もり
+
+| Phase | 工数 |
+|-------|------|
+| Phase 0: 準備 | 5分 |
+| Phase 1: コンポーネント改修 | 20分 |
+| Phase 2: デモリファクタ | 10分 |
+| Phase 3: ドキュメント | 5分 |
+| Phase 4: 影響確認 | 10分 |
+| Phase 5: 検証 | 10分 |
+| Phase 6: PR | 10分 |
+| **合計** | **約70分** |
+
+---
+
+## 関連
+
+- [pt-icon コンポーネント](../../src/app/ui/pt-icon/)
+- [Icon NgDoc ドキュメント](../../projects/docs/src/components/icon/)
+- [コンポーネント実装ワークフロー](../../.agent/workflows/component.md)
+- [コンポーネントドキュメントワークフロー](../../.agent/workflows/component-doc.md)

--- a/projects/docs/src/components/icon/demos/playground.component.ts
+++ b/projects/docs/src/components/icon/demos/playground.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, inject } from '@angular/core';
 import { IconComponent } from '@ui/pt-icon/pt-icon';
 import { AssetPathService } from '@app/core/services/asset-path.service';
+import type { IconSize, IconColor } from '@ui/pt-icon/pt-icon.types';
+import type { PokemonType } from '@domain/type-chart';
 
 /**
  * Playground wrapper for Icon
@@ -13,6 +15,7 @@ import { AssetPathService } from '@app/core/services/asset-path.service';
 		<pt-icon
 			[src]="iconPath"
 			[size]="size"
+			[color]="color"
 			[alt]="alt"
 		></pt-icon>
 	`,
@@ -20,8 +23,9 @@ import { AssetPathService } from '@app/core/services/asset-path.service';
 export class IconPlaygroundComponent {
 	private readonly assetPath = inject(AssetPathService);
 
-	@Input() iconName = 'fire';
-	@Input() size: 'sm' | 'md' | 'lg' = 'md';
+	@Input() iconName: PokemonType = 'fire';
+	@Input() size: IconSize = 'md';
+	@Input() color: IconColor = 'fire';
 	@Input() alt = '';
 
 	get iconPath(): string {

--- a/projects/docs/src/components/icon/demos/sizes-demo.component.ts
+++ b/projects/docs/src/components/icon/demos/sizes-demo.component.ts
@@ -11,19 +11,7 @@ import { AssetPathService } from '@app/core/services/asset-path.service';
 	imports: [IconComponent],
 	template: `
 		@for (size of sizes; track size) {
-			<div class="icon-demo-wrapper">
-				<pt-icon [src]="iconPath" [size]="size"></pt-icon>
-			</div>
-		}
-	`,
-	styles: `
-		.icon-demo-wrapper {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			padding: var(--pt-space-2);
-			background: var(--pt-color-pokemon-fire-500);
-			border-radius: var(--pt-border-radius-md);
+			<pt-icon [src]="iconPath" [size]="size" color="fire"></pt-icon>
 		}
 	`,
 })
@@ -35,4 +23,3 @@ export class IconSizesDemoComponent {
 		return this.assetPath.icon('fire');
 	}
 }
-

--- a/projects/docs/src/components/icon/demos/types-demo.component.ts
+++ b/projects/docs/src/components/icon/demos/types-demo.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { IconComponent } from '@ui/pt-icon/pt-icon';
 import { AssetPathService } from '@app/core/services/asset-path.service';
+import type { IconColor } from '@ui/pt-icon/pt-icon.types';
 
 /**
  * Demo: Icon Type Icons
@@ -11,31 +12,15 @@ import { AssetPathService } from '@app/core/services/asset-path.service';
 	imports: [IconComponent],
 	template: `
 		@for (type of types; track type) {
-			<div class="icon-demo-wrapper" [style.background]="getTypeColor(type)">
-				<pt-icon [src]="getIconPath(type)" size="md"></pt-icon>
-			</div>
-		}
-	`,
-	styles: `
-		.icon-demo-wrapper {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			padding: var(--pt-space-2);
-			border-radius: var(--pt-border-radius-md);
+			<pt-icon [src]="getIconPath(type)" size="md" [color]="type"></pt-icon>
 		}
 	`,
 })
 export class IconTypesDemoComponent {
 	private readonly assetPath = inject(AssetPathService);
-	readonly types = ['fire', 'water', 'grass', 'electric', 'ice', 'fighting'] as const;
+	readonly types: IconColor[] = ['fire', 'water', 'grass', 'electric', 'ice', 'fighting'];
 
 	getIconPath(type: string): string {
 		return this.assetPath.icon(type);
 	}
-
-	getTypeColor(type: string): string {
-		return `var(--pt-color-pokemon-${type}-500)`;
-	}
 }
-

--- a/projects/docs/src/components/icon/examples.md
+++ b/projects/docs/src/components/icon/examples.md
@@ -9,8 +9,8 @@ route: examples
 
 {{ NgDocActions.demo("IconSizesDemoComponent") }}
 
-## Type Icons
+## Colored Icons
 
-ポケモンのタイプアイコン：
+`color` プロパティでタイプカラーを直接アイコンに適用：
 
 {{ NgDocActions.demo("IconTypesDemoComponent") }}

--- a/src/app/ui/pt-icon/index.ts
+++ b/src/app/ui/pt-icon/index.ts
@@ -1,1 +1,4 @@
 export { IconComponent } from './pt-icon';
+export type { IconSize, IconColor } from './pt-icon.types';
+export { ICON_SIZES } from './pt-icon.types';
+

--- a/src/app/ui/pt-icon/pt-icon.html
+++ b/src/app/ui/pt-icon/pt-icon.html
@@ -1,1 +1,8 @@
+@if (color) {
+<!-- Color mode: CSS mask -->
+<div [ngClass]="iconClasses" [style.background-color]="iconColor" [style.mask-image]="maskImageUrl"
+	[style.-webkit-mask-image]="maskImageUrl" role="img" [attr.aria-label]="alt || null"></div>
+} @else {
+<!-- Legacy mode: img tag (backward compatible) -->
 <img [ngClass]="iconClasses" [src]="src" [alt]="alt">
+}

--- a/src/app/ui/pt-icon/pt-icon.scss
+++ b/src/app/ui/pt-icon/pt-icon.scss
@@ -1,6 +1,6 @@
 /**
  * @what Icon component styles
- * @why Provide flexible icon display using Design Tokens
+ * @why Provide flexible icon display with color support using Design Tokens
  *
  * @tokens Tier 3: icon.json
  */
@@ -14,6 +14,17 @@
 .pt-icon {
 	display: block;
 	object-fit: contain;
+
+	// CSS mask styles (for color mode)
+	mask-size: contain;
+	mask-repeat: no-repeat;
+	mask-position: center;
+	// stylelint-disable-next-line property-no-vendor-prefix -- Safari requires -webkit prefix for mask properties
+	-webkit-mask-size: contain;
+	// stylelint-disable-next-line property-no-vendor-prefix
+	-webkit-mask-repeat: no-repeat;
+	// stylelint-disable-next-line property-no-vendor-prefix
+	-webkit-mask-position: center;
 
 	// Size variants
 	&--sm {

--- a/src/app/ui/pt-icon/pt-icon.ts
+++ b/src/app/ui/pt-icon/pt-icon.ts
@@ -1,12 +1,20 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { IconSize, IconColor } from './pt-icon.types';
 
 /**
- * Icon component for displaying icons
- * 
+ * Icon component for displaying icons with optional color support
+ *
  * @example
+ * <!-- Type color -->
+ * <pt-icon [src]="'/icons/fire.svg'" size="md" color="fire"></pt-icon>
+ *
+ * <!-- Inverse (white) for dark backgrounds -->
+ * <pt-icon [src]="'/icons/fire.svg'" size="md" color="inverse"></pt-icon>
+ *
+ * <!-- Inherit parent color (default) -->
  * <pt-icon [src]="'/icons/fire.svg'" size="md"></pt-icon>
- * 
+ *
  * @reference
  * - Atomic Design: Atom (Generic component)
  * - GitHub Primer: https://primer.style/components/icon
@@ -29,7 +37,7 @@ export class IconComponent {
    * Size of the icon
    * @default 'md'
    */
-  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() size: IconSize = 'md';
 
   /**
    * Alternative text for accessibility
@@ -38,9 +46,34 @@ export class IconComponent {
   @Input() alt = '';
 
   /**
+   * Color of the icon
+   * - PokemonType: Applies the type's color (e.g., 'fire', 'water')
+   * - 'inverse': White color for dark backgrounds
+   * - undefined: Inherits parent color via currentColor (default)
+   */
+  @Input() color?: IconColor;
+
+  /**
    * Icon element classes
    */
   get iconClasses(): string[] {
     return ['pt-icon', `pt-icon--${this.size}`];
+  }
+
+  /**
+   * Computed color value for CSS mask mode
+   * Returns CSS variable or null if no color is set
+   */
+  get iconColor(): string | null {
+    if (!this.color) return null;
+    if (this.color === 'inverse') return 'var(--pt-color-text-inverse)';
+    return `var(--pt-color-pokemon-${this.color}-500)`;
+  }
+
+  /**
+   * CSS mask-image URL for color mode
+   */
+  get maskImageUrl(): string {
+    return `url(${this.src})`;
   }
 }

--- a/src/app/ui/pt-icon/pt-icon.types.ts
+++ b/src/app/ui/pt-icon/pt-icon.types.ts
@@ -1,0 +1,6 @@
+import { PokemonType } from '@domain/type-chart';
+
+export const ICON_SIZES = ['sm', 'md', 'lg'] as const;
+export type IconSize = (typeof ICON_SIZES)[number];
+
+export type IconColor = PokemonType | 'inverse';


### PR DESCRIPTION
## 💡 概要

`pt-icon` コンポーネントに `color` プロパティを追加し、タイプカラーでアイコンを着色できるようにしました。

これにより、背景色なしでもアイコンが視認可能になり、よりフレキシブルなアイコン表示が可能になります。

## 📝 変更内容

### コンポーネント改修
- `pt-icon.types.ts`: `IconColor` 型を追加（PokemonType | 'inverse'）
- `pt-icon.ts`: `color` input と `iconColor`, `maskImageUrl` getter を追加
- `pt-icon.html`: `color` 指定時は CSS mask、未指定時は従来の img タグを使用
- `pt-icon.scss`: CSS mask 用スタイル追加

### デモリファクタ
- `sizes-demo.component.ts`: 背景ラッパー削除、`color="fire"` を使用
- `types-demo.component.ts`: 背景ラッパー削除、各タイプカラーを `[color]` で適用
- `playground.component.ts`: `color` プロパティを Playground に追加

### ドキュメント
- `examples.md`: "Colored Icons" セクションに更新

## 🔗 関連Issue

なし（計画書 `docs/temp/pt-icon-color-refactor-plan.md` に基づく実装）

## 📷 スクリーンショット（該当する場合）

実装後、http://localhost:4300/#/components/icon/examples でご確認ください。

## ✅ チェックリスト

- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [x] 必要に応じてドキュメントを更新した

## 📌 補足事項

### 後方互換性
- `color` プロパティが未指定の場合は従来通り `<img>` タグでレンダリングされます
- 既存の使用箇所に影響なし

### 技術的な選択
- CSS mask を使用してアイコンの色を変更
- Safari 互換性のため `-webkit-` プレフィックスを使用

--- 

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🩹 fix: バグ修正
- 🐛 bug: バグ報告（Issue用）
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他
- ❓ question: 質問・議論（Issue用）
- ⏪ revert: 変更を元に戻す
- 💥 breaking: 破壊的変更
- 🚧 wip: 作業中

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集
<!-- レビュー時によく使う用語の意味 -->

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
