### PR TITLE
⚡ perf: add image preloading for faster quiz transitions

### DIFF
--- a/src/app/domain/pokemon.service.ts
+++ b/src/app/domain/pokemon.service.ts
@@ -7,15 +7,56 @@ import { Pokemon, parsePokemonList } from './pokemon.schema';
   providedIn: 'root',
 })
 export class PokemonService {
+  /** キャッシュされたポケモンリスト */
+  private pokemonsCache: Pokemon[] | null = null;
+
+  /** プリロード中の画像URLセット */
+  private preloadedImages = new Set<string>();
+
   constructor(private http: HttpClient) { }
 
+  /**
+   * ポケモンリストを取得（キャッシュあり）
+   */
   async getPokemons(): Promise<Pokemon[]> {
+    if (this.pokemonsCache) {
+      return this.pokemonsCache;
+    }
+
     const data = await firstValueFrom(this.http.get<unknown[]>('/pokemons.json'));
-    return parsePokemonList(data);
+    this.pokemonsCache = parsePokemonList(data);
+    return this.pokemonsCache;
   }
 
+  /**
+   * ランダムなポケモンを取得
+   */
   async getRandomPokemon(): Promise<Pokemon> {
     const pokemons = await this.getPokemons();
     return pokemons[Math.floor(Math.random() * pokemons.length)];
+  }
+
+  /**
+   * ポケモン画像をプリロード
+   * @param pokemon - プリロードするポケモン
+   * @returns プリロード完了時に解決される Promise
+   */
+  preloadImage(pokemon: Pokemon): Promise<void> {
+    if (this.preloadedImages.has(pokemon.imageUrl)) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        this.preloadedImages.add(pokemon.imageUrl);
+        resolve();
+      };
+      img.onerror = () => {
+        // エラー時も resolve（画像読み込み失敗は許容）
+        resolve();
+      };
+      img.src = pokemon.imageUrl;
+    });
   }
 }


### PR DESCRIPTION
## 💡 概要
ポケモン画像のプリロード機能を追加し、Quiz画面の次の問題への遷移を高速化しました。

## 📝 変更内容

### PokemonService (`pokemon.service.ts`)
- **ポケモンリストのキャッシュ**: `pokemons.json` を毎回フェッチせず、初回のみ取得してキャッシュ
- **画像プリロード機能**: `preloadImage()` メソッドを追加。次の問題のポケモン画像を事前にブラウザキャッシュに読み込む

### QuizComponent (`quiz.container.ts`)
- **次の問題の事前準備**: 現在の問題を表示中に、次の問題データと画像をバックグラウンドで取得
- **即座な問題遷移**: 回答後、プリロード済みの次の問題を即座に表示

### 改善効果
- **ポケモンリスト取得**: 毎回の HTTP フェッチ → 初回のみ（キャッシュ）
- **画像表示**: 問題遷移時に読み込み開始 → 事前にプリロード済み
- **体感速度**: 画像が即座に表示され、遅延感が解消

## 🔗 関連Issue
Closes #77

## 📷 スクリーンショット（該当する場合）
N/A（パフォーマンス改善のため、視覚的な変更なし）

## ✅ チェックリスト
- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [x] 必要に応じてドキュメントを更新した


## 📌 補足事項
### 技術的な実装詳細

```
[問題1表示] → [回答] → [問題2表示] → [回答] → ...
     |              |
     v              v
  [問題2準備]    [問題3準備]
  (データ取得 +   (データ取得 +
   画像プリロード)  画像プリロード)
```

画像プリロードは `new Image()` を使用し、ブラウザの画像キャッシュを活用しています。

--- 

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🩹 fix: バグ修正
- 🐛 bug: バグ報告（Issue用）
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他
- ❓ question: 質問・議論（Issue用）
- ⏪ revert: 変更を元に戻す
- 💥 breaking: 破壊的変更
- 🚧 wip: 作業中

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
