### PR TITLE
🩹 fix: update token-naming Stylelint pattern from --pt-spacing- to --pt-space-

### DIFF
--- a/guards/design/guard/token-naming.guard.md
+++ b/guards/design/guard/token-naming.guard.md
@@ -35,7 +35,7 @@ UI実装（SCSS/CSS）でPrimitiveトークン（Tier 1）を直接使用する�
 - `--pt-color-red-*`
 - `--pt-color-white`
 - `--pt-color-black`
-- `--pt-spacing-{number}`
+- `--pt-space-{number}` (例: `--pt-space-10`, `--pt-space-20`)
 
 ### 2. トークン命名規則
 

--- a/guards/design/rules/token-naming.rules.js
+++ b/guards/design/rules/token-naming.rules.js
@@ -21,8 +21,8 @@ const PRIMITIVE_TOKEN_PATTERNS = [
 	// カラー: 基本色
 	'/var\\(\\s*--pt-color-white/',
 	'/var\\(\\s*--pt-color-black/',
-	// スペーシング: 数値ベース
-	'/var\\(\\s*--pt-spacing-\\d/',
+	// スペーシング: Primitive数値ベース（--pt-space-XX）
+	'/var\\(\\s*--pt-space-\\d/',
 ];
 
 /**
@@ -39,6 +39,7 @@ const PRIMITIVE_TOKEN_PATTERNS = [
  * - --pt-badge-*
  * - --pt-spacing-content-*
  * - --pt-spacing-layout-*
+ * - --pt-spacing-gap-*
  */
 
 const GUARDRAIL_PATH = 'guards/design/guard/token-naming.guard.md';
@@ -56,6 +57,12 @@ module.exports = {
 				'/border/': PRIMITIVE_TOKEN_PATTERNS,
 				'/fill/': PRIMITIVE_TOKEN_PATTERNS,
 				'/stroke/': PRIMITIVE_TOKEN_PATTERNS,
+				// スペーシング関連プロパティでPrimitiveトークンを禁止
+				'/gap/': PRIMITIVE_TOKEN_PATTERNS,
+				'/padding/': PRIMITIVE_TOKEN_PATTERNS,
+				'/margin/': PRIMITIVE_TOKEN_PATTERNS,
+				'/width/': PRIMITIVE_TOKEN_PATTERNS,
+				'/height/': PRIMITIVE_TOKEN_PATTERNS,
 			},
 			{
 				message: `Primitiveトークン禁止。Semantic/Componentを使用 (${GUARDRAIL_PATH})`,


### PR DESCRIPTION
## 💡 概要
`token-naming.rules.js` のStylelintパターンを修正。10倍命名リネーム後のプリミティブスペーストークン (`--pt-space-`) を正しく検出できるようにし、スペーシング関連CSSプロパティにもルールを適用。

## 📝 変更内容
- `guards/design/rules/token-naming.rules.js`:
  - パターン修正: `--pt-spacing-\d` → `--pt-space-\d`（Primitiveトークンの正しい検出）
  - スペーシング関連プロパティ追加: `gap`, `padding`, `margin`, `width`, `height`
  - 許可パターンコメントに `--pt-spacing-gap-*` を追加
- `guards/design/guard/token-naming.guard.md`:
  - 禁止パターンの記述を `--pt-spacing-{number}` → `--pt-space-{number}` に修正

## 🔗 関連Issue
Refs #41

## 📷 スクリーンショット（該当する場合）
N/A（Stylelintルール修正のみ）

## ✅ チェックリスト
- [x] ビルドが成功する（`npm run build`）
- [x] Lintエラーがない（`npm run lint`）
- [x] テストが通る（`npm run test`）
- [x] コミットメッセージが規約に従っている（`feat:`, `fix:`, `chore:`など）
- [x] ブランチ名が規約に従っている（`feature/`, `fix/`, `chore/`など）
- [x] 必要に応じてドキュメントを更新した

## 📌 補足事項
### 修正の背景
PR #146 でスペーストークンを10倍命名にリネーム(`space.1` → `space.10`)した結果、生成されるCSS変数名が `--pt-space-10` 等に変わった。しかしStylelintの禁止パターンが旧名の `--pt-spacing-\d` のままだったため、新しいプリミティブトークンの直接使用を検出できなくなっていた。

--- 

## 📝 PRタイトルの命名規則:
- `type: description` の形式にすること（Conventional Commits）
- **英語で書くこと**（commitlint で検証されます）

タイプ一覧（絵文字は任意）:
- ✨ feat: 新機能
- 🩹 fix: バグ修正
- 🐛 bug: バグ報告（Issue用）
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他
- ❓ question: 質問・議論（Issue用）
- ⏪ revert: 変更を元に戻す
- 💥 breaking: 破壊的変更
- 🚧 wip: 作業中

例: `feat: add sound effects and toggle switch`

## 📖 レビュー用語集
<!-- レビュー時によく使う用語の意味 -->

| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |
